### PR TITLE
[Qt] GUI Re-skinned and Receive Page address removed

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -86,13 +86,6 @@ void ReceiveCoinsDialog::setModel(WalletModel* model)
         // Last 2 columns are set by the columnResizingFixer, when the table geometry is ready.
         columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(tableView, AMOUNT_MINIMUM_COLUMN_WIDTH, DATE_COLUMN_WIDTH);
 
-        // Init address field
-        QSettings settings;
-        address = settings.value("current_receive_address").toString();
-        if (address.isEmpty())
-            address = getAddress();
-        ui->reqAddress->setText(address);
-
         connect(model, SIGNAL(notifyReceiveAddressChanged()), this, SLOT(receiveAddressUsed()));
     }
 }

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -92,15 +92,12 @@ void ReceiveCoinsDialog::setModel(WalletModel* model)
 
 ReceiveCoinsDialog::~ReceiveCoinsDialog()
 {
-    QSettings settings;
-    settings.setValue("current_receive_address", address);
     delete ui;
 }
 
 void ReceiveCoinsDialog::clear()
 {
     ui->reqAmount->clear();
-    ui->reqAddress->setText(address);
     ui->reqLabel->setText("");
     ui->reqMessage->setText("");
     ui->reuseAddress->setChecked(false);

--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -1,16 +1,16 @@
 /****************************************************************************************/
 /* Global color codes:                                                                  */
-/* dark-purple:        #382f44                                                          */
-/* transparent-purple: #e9e7ef (for inactive backgrounds)                               */
+/* dark-green:         #304530                                                          */
+/* transparent-green:  #e7efe7 (for inactive backgrounds)                               */
 /*                                                                                      */
-/* light-purple1:      #b396f6 (main purple for white backgrounds)                      */
-/* light-purple2:      #9179c7 (sligtly darker for gradients)                           */
+/* light-green1:       #98f698 (main green for white backgrounds)                       */
+/* light-green2:       #7ac77a (sligtly darker for gradients)                           */
 /*                                                                                      */
-/* medium-purple1:     #6f5ca3 (on hover)                                               */
-/* medium-purple1:     #5c4c7c (main purple for dark backgrounds)                       */
-/* medium-purple2:     #5b4c86 (sligtly darker for gradients)                           */
+/* medium-green1:      #5ca35c (on hover)                                               */
+/* medium-green1:      #4c7b4c (main green for dark backgrounds)                        */
+/* medium-green2:      #4b864b (sligtly darker for gradients)                           */
 /*                                                                                      */
-/* fuchsia:            #df1cca                                                          */
+/* mint:               #00cc66                                                          */
 /* background:         #f8f6f6                                                          */
 /* input fields:       #e7e7e7                                                          */
 /****************************************************************************************/
@@ -22,1729 +22,1720 @@
 /****************************************************************************************/
 
 WalletFrame {
-background-color:#ffffff;
-border-top:0px solid #000;
-margin:0;
-padding:0;
-}
-
-QStatusBar {
-background-color:#ffffff;
-}
-
-.QFrame {
-background-color:transparent;
-border:0px solid #fff;
-}
-
-QMenuBar {
-background-color:#fff;
-}
-
-QMenuBar::item {
-background-color:#fff;
-color:#333;
-}
-
-QMenuBar::item:selected {
-background-color:#f8f6f6;
-}
-
-QMenu {
-background-color:#f8f6f6;
-}
-
-QMenu::item {
-color:#333;
-}
-
-QMenu::item:selected {
-background-color:#f2f0f0;
-color:#333;
-}
-
-QToolBar {
-background-color: qlineargradient(y1:0, y2: 1, stop: 0 #372f44, stop: 0.75 #372f44, stop: 0.99 #ffffff, stop: 1 #ffffff);
-border:0px solid #333;
-padding:1;
-margin:0;
-width: 70px;
-}
-
-QToolBar > QToolButton {
-Alignment: left;
-background-color: #372f44;
-selection-background-color:transparent;
-border:0.5px solid #888;
-border-left: 0px;
-border-right: 0px;
-border-top: 0px;
-min-height:2.5em;
-padding: 0em 0em;
-font-size: 11px;
-color:#aaa;
-width: 80px;
-height: 60px;
-}
-
-QToolBar > QToolButton:checked {
-background-color: qlineargradient(x1:0, x2: 1, stop: 0 #ffffff, stop: 0.07 #ffffff, stop: 0.0701 #372f44, stop: 1 #372f44);
-color:#fff;
-}
-
-/* QToolBar > QToolButton:hover:!selected { */
-QToolBar > QToolButton:hover {
-background-color: qlineargradient(x1:0, x2: 1, stop: 0 #ffffff, stop: 0.07 #ffffff, stop: 0.0701 #372f44, stop: 1 #372f44);
-color:#fff;
-}
-
-QToolBar > QToolButton#ToolbarSpacer:hover:!selected {
-background-color: #372f44; /* Do not highlight placeholder on hover */
-}
-
-QToolBar > QToolButton:pressed {
-background-color: qlineargradient(x1:0, x2: 1, stop: 0 #00a300, stop: 0.07 #00a300, stop: 0.0701 #372f44, stop: 1 #372f44);
-color:#fff;
-}
-
-QMessageBox {
-background-color:#fff;
-}
-
-QProgressBar {
-color: #AAAAAA;
-border:0px solid grey;
-border-radius:5px;
-background-color:transparent;
-padding-left:0px;
-padding-right:0px;
-}
-
-QProgressBar::chunk {
-background-color:#5c4c7c;
-width: 20px;
-}
-
-QLabel#progressBarLabel {
-background-color:transparent;
-color: #382f44;
-padding-left:5px;
-padding-right:5px;
-}
-
-QTabWidget {
-background-color:#f2f2f2;
-}
-
-QTabWidget::pane {
-background-color:#f2f2f2;
-border:1px solid #c2c2c2;
-}
-
-QTabBar {
-background-color:#f2f2f2;
-color:#333;
-}
-
-QTabBar::tab:hover:!selected {
-background-color:#dedbe5;
-}
-
-QWidget {
-selection-background-color:#5c4c7c; /* Object highlight color */
-selection-color:#fff;
-outline:0; /* Remove Annoying Focus Rectangle */
-}
-
-QGroupBox {
-background-color:#fcfcfc;
-color:#333;
-}
-
-QToolTip {
-background-color:#dedbe5;
-color:#333;
-}
-
-/****************************************************************************************/
-
-QLabel { /* Base Text Size & Color */
-font-size:12px;
-color:#333333;
-}
-
-.QRadioButton { /* Radio Button Labels */
-color:#333333;
-}
-
-.QCheckBox { /* Checkbox Labels */
-color:#333333;
-}
-
-.QCheckBox:hover {
-}
-
-.QValidatedLineEdit, .QLineEdit, .QTextEdit { /* Text Entry Fields */
-font-size:12px;
-min-height:25px;
-outline:0;
-padding:3px;
-border:0px;
-color:#333;
-background-color:#f2f2f2;
-}
-
-.QValidatedLineEdit:!focus {
-color:#5c4c7c;
-background-color:#e7e7e7;
-}
-
-.QLineEdit:!focus {
-color:#5c4c7c;
-background-color:#e7e7e7;
-}
-
-.QTextEdit:!focus {
-color:#5c4c7c;
-background-color:#e7e7e7;
-}
-
-/* .QValidatedLineEdit:checked, .QLineEdit:checked */
-
-.QValidatedLineEdit:disabled, .QLineEdit:disabled, .QTextEdit:disabled {
-color: #5c4c7c;
-background-color:#f2f2f2;
-}
-
-.QPlainTextEdit {
-background-color:#f2f2f2;
-}
-
-/***************************** Global Qt Objects ***********************************************************/
-
-QPushButton { /* Global Button Style */
-background-color: #5c4c7c;
-border-width: 1px;
-border-style: outset;
-border-color: #382f44;
-border-radius: 2px;
-color:#ffffff;
-font-size:12px;
-font-weight:bold;
-padding-left:25px;
-padding-right:25px;
-padding-top:1px;
-padding-bottom:1px;
-height: 26px;
-margin: 2px;
-}
-
-QPushButton:hover {
-background-color: qlineargradient(y1:0, y2: 1, stop: 0 #ffffff, stop: 0.1 #ffffff, stop: 0.101 #6f5ca3, stop: 0.9 #6f5ca3, stop: 0.901 #ffffff, stop: 1 #ffffff);
-}
-
-QPushButton:focus {
-/* border:none; */
-/* outline:none; */
-}
-
-QPushButton:pressed {
-background-color: #5c4c7c;
-border:1px solid #000000;
-background-color: qlineargradient(y1:0, y2: 1, stop: 0 #00ff00, stop: 0.1 #00ff00, stop: 0.101 #6f5ca3, stop: 0.9 #6f5ca3, stop: 0.901 #00ff00, stop: 1 #00ff00);
-}
-
-/* Special handling for statusbar-icons (which are partly QPushButtons) */
-QPushButton#labelEncryptionIcon, QPushButton#labelConnectionsIcon, QPushButton#labelAutoMintIcon {
-border: 0px;
-padding-left:0px;
-padding-right:0px;
-padding-top:0px;
-padding-bottom:0px;
-margin: 0px;
-}
-
-/* QSpinBox::up-arrow:hover */
-/* QSpinBox::down-arrow:hover */
-
-QSpinBox::up-button:hover {
-background-color: #f2f2f2;
-}
-
-QSpinBox::down-button:hover {
-background-color: #f2f2f2;
-}
-
-QComboBox { /* Dropdown Menus */
-border:1px solid #5c4c7c;
-padding: 3px 5px 3px 5px;
-background:#fcfcfc;
-min-height:25px;
-color:#818181;
-}
-
-QComboBox:checked {
-background:#f2f2f2;
-}
-
-QComboBox:editable {
-background:#382f44;
-color:#616161;
-border:0px solid transparent;
-}
-
-QComboBox::drop-down {
-width:25px;
-border:0px;
-}
-
-QComboBox::down-arrow {
-border-image: url(':/images/downArrow') 0 0 0 0 stretch stretch;
-}
-
-QComboBox QListView {
-background:#fff;
-border:1px solid #333;
-padding-right:1px;
-padding-left:1px;
-color:#818181;
-}
-
-QComboBox QAbstractItemView::item {
-margin:4px;
-}
-
-QComboBox::item {
-color:#818181;
-}
-
-QComboBox::item:alternate {
-background:#fff;
-}
-
-QComboBox::item:selected {
-border:0px solid transparent;
-background:#f2f2f2;
-}
-
-QComboBox::indicator {
-background-color:transparent;
-selection-background-color:transparent;
-color:transparent;
-selection-color:transparent;
-}
-
-QAbstractSpinBox {
-padding: 3px 5px 3px 5px;
-background:#fcfcfc;
-font-size:12px;
-min-height:25px;
-outline:0;
-padding:3px;
-border:0px;
-color:#333;
-background-color:#f2f2f2;
-}
-
-QAbstractSpinBox:!focus {
-color:#5c4c7c;
-background-color:#e7e7e7;
-}
-
-QAbstractSpinBox::up-button {
-subcontrol-origin: border;
-subcontrol-position: top right;
-width:21px;
-background:#e7e7e7; /* Remove this to get 3D rendered buttons */
-padding-right:1px;
-padding-left:5px;
-padding-top:2px;
-}
-
-QAbstractSpinBox::up-arrow {
-image:url(':/images/upArrow_small');
-}
-
-QAbstractSpinBox::down-button {
-subcontrol-origin: border;
-subcontrol-position: bottom right;
-width:21px;
-background:#e7e7e7; /* Remove this to get 3D rendered buttons */
-padding-right:1px;
-padding-left:5px;
-padding-bottom:2px;
-}
-
-QAbstractSpinBox::down-arrow {
-image:url(':/images/downArrow_small');
-}
-
-QValueComboBox {
-padding: 3px 5px 3px 5px;
-background:#fcfcfc;
-font-size:12px;
-min-height:25px;
-outline:0;
-padding:3px;
-border:0px;
-color:#333;
-background-color:#f2f2f2;
-}
-
-QValueComboBox:!focus {
-color:#5c4c7c;
-background-color:#e7e7e7;
-}
-
-/****************************************************************************************/
-
-QHeaderView { /* Table Header */
-background-color:transparent;
-outline:0;
-}
-
-QHeaderView::section { /* Table Header Sections */
-qproperty-alignment:center;
-background-color: #5c4c7c;
-color:#fff;
-min-height:25px;
-font-weight:bold;
-font-size:11px;
-border:0;
-border-right:1px solid #fff;
-padding-left:5px;
-padding-right:5px;
-padding-top:2px;
-padding-bottom:2px;
-}
-
-QHeaderView::down-arrow {
-    image: url(':/images/downArrow_small_white');
-}
-
-QHeaderView::up-arrow {
-    image: url(':/images/upArrow_small_white');
-}
-
-QHeaderView::section:last {
-border-right:0;
-}
-
-.QScrollArea {
-background:transparent;
-border:0;
-}
-
-.QTableView { /* Table - has to be selected as a class otherwise it throws off QCalendarWidget */
-background:transparent;
-border:1px solid #333;
-}
-
-QTableView::item { /* Table Item */
-background-color:#fcfcfc;
-font-size:12px;
-}
-
-QTableView::item:selected { /* Table Item Selected */
-background-color:#5c4c7c;
-color:#fff;
-}
-
-QTableWidget { /* Table Background */
-background-color: #fcfcfc;
-alternate-background-color: yellow;
-border:1px solid #333;
-}
-
-QTableWidget:focus, QTableView, QTableView:focus { /* Remove focus outline */
-outline:0;
-background:transparent;
-}
-
-QTreeWidget { /* Tree Background */
-background-color:#fcfcfc;
-alternate-background-color:#f2f2f2;
-color:#333;
-}
-
-QScrollBar { /* Scroll Bar */
-
-}
-
-QScrollBar:vertical { /* Vertical Scroll Bar Attributes */
-border:0;
-background:#5c4c7c;
-width:18px;
-margin:18px 0px 18px 0px;
-}
-
-QScrollBar:horizontal { /* Horizontal Scroll Bar Attributes */
-border:0;
-background:#5c4c7c;
-height:18px;
-margin:0px 18px 0px 18px;
-}
-
-QScrollBar::handle:vertical { /* Scroll Bar Slider - vertical */
-background:#5c4c7c;
-min-height:10px;
-}
-
-QScrollBar::handle:vertical:pressed { /* Scroll Bar Slider - vertical */
-background:#9179c7;
-min-height:10px;
-}
-
-QScrollBar::handle:horizontal { /* Scroll Bar Slider - horizontal */
-background:#5c4c7c;
-min-width:10px;
-}
-
-QScrollBar::handle:horizontal:pressed { /* Scroll Bar Slider - horizontal */
-background:#9179c7;
-min-width:10px;
-}
-
-QScrollBar::add-page, QScrollBar::sub-page { /* Scroll Bar Background */
-background:#F8F6F6;
-}
-
-QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical, QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal { /* Define Arrow Button Dimensions */
-background-color:#F8F6F6;
-border: 1px solid #f2f0f0;
-width:16px;
-height:16px;
-}
-
-QScrollBar::add-line:vertical:pressed, QScrollBar::sub-line:vertical:pressed, QScrollBar::add-line:horizontal:pressed, QScrollBar::sub-line:horizontal:pressed {
-background-color:#e0e0e0;
-}
-
-QScrollBar::sub-line:vertical { /* Vertical - top button position */
-subcontrol-position:top;
-subcontrol-origin: margin;
-}
-
-QScrollBar::add-line:vertical { /* Vertical - bottom button position */
-subcontrol-position:bottom;
-subcontrol-origin: margin;
-}
-
-QScrollBar::sub-line:horizontal { /* Vertical - left button position */
-subcontrol-position:left;
-subcontrol-origin: margin;
-}
-
-QScrollBar::add-line:horizontal { /* Vertical - right button position */
-subcontrol-position:right;
-subcontrol-origin: margin;
-}
-
-QScrollBar:up-arrow, QScrollBar:down-arrow, QScrollBar:left-arrow, QScrollBar:right-arrow { /* Arrows Icon */
-width:10px;
-height:10px;
-}
-
-QScrollBar:up-arrow {
-background-image: url(':/images/upArrow_small');
-}
-
-QScrollBar:down-arrow {
-background-image: url(':/images/downArrow_small');
-}
-
-QScrollBar:left-arrow {
-background-image: url(':/images/leftArrow_small');
-}
-
-QScrollBar:right-arrow {
-background-image: url(':/images/rightArrow_small');
-}
-
-QSlider::groove:horizontal {
-border: 1px solid #bbb;
-background: white;
-height: 6px;
-border-radius: 4px;
-}
-
-QSlider::sub-page:horizontal {
-/* background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #5B4C86, stop: 1 #7b67a9); */
-background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #9179c7, stop: 1 #b396f6);
-border: 1px solid #333;
-height: 10px;
-border-radius: 4px;
-}
-
-QSlider::add-page:horizontal {
-background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #5c4c7c, stop: 1 #9179c7);
-border: 1px solid #333;
-height: 10px;
-border-radius: 4px;
-}
-
-QSlider::handle:horizontal {
-background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #fff, stop:1 #f8f6f6);
-border: 1px solid #333;
-width: 18px;
-height: 18px;
-margin-top: -6px;
-margin-bottom: -6px;
-border-radius: 9px;
-}
-
-QSlider::handle:horizontal:hover {
-background-color: qradialgradient(cx: 0.5, cy: 0.5, fx: 0.5, fy: 0.5, radius: 0.7, stop: 0 #5c4c7c, stop: 0.7 #ffffff);
-border: 2px solid #333;
-width: 16px;
-height: 16px;
-margin-top: -6px;
-margin-bottom: -6px;
-border-radius: 8px;
-}
-
-/**************************** DIALOG BOXES **********************************************/
-
-QDialog {
-background-color: #fff;
-}
-AskPassphraseDialog {
-background-color: #fff;
-}
-
-
-QDialog .QTabWidget {
-border-bottom:1px solid #333;
-}
-
-QDialog .QTabWidget::pane {
-border: 1px solid #d7d7d7;
-}
-
-QDialog .QTabWidget QTabBar::tab {
-background-color:#f8f6f6;
-color:#333;
-padding-left:10px;
-padding-right:10px;
-padding-top:5px;
-padding-bottom:5px;
-border-top: 1px solid #d7d7d7;
-}
-
-QDialog .QTabWidget QTabBar::tab:first {
-border-left: 1px solid #d7d7d7;
-}
-
-QDialog .QTabWidget QTabBar::tab:last {
-border-right: 1px solid #d7d7d7;
-}
-
-QDialog .QTabWidget QTabBar::tab:selected, QDialog .QTabWidget QTabBar::tab:hover {
-background-color:#ffffff;
-color:#333;
-}
-
-QDialog .QTabWidget .QWidget {
-background-color:#fff;
-color:#333;
-}
-
-QDialog .QTabWidget .QWidget QAbstractSpinBox {
-min-height:15px;
-}
-
-QDialog .QTabWidget .QWidget QAbstractSpinBox::down-button {
-width:15px;
-}
-
-QDialog .QTabWidget .QWidget QAbstractSpinBox::up-button {
-width:15px;
-}
-
-QDialog .QTabWidget .QWidget QComboBox {
-min-height:15px;
-}
-
-/**************************** FILE MENU *************************************************/
-
-/* Dialog: Open URI */
-QDialog#OpenURIDialog QLabel#label { /* URI Label */
-font-weight:bold;
-}
-
-QDialog#OpenURIDialog QPushButton#selectFileButton { /* ... Button */
-background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
-border:1px solid #d2d2d2;
-color:#616161;
-padding-left:10px;
-padding-right:10px;
-}
-
-QDialog#OpenURIDialog QPushButton#selectFileButton:hover {
-background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(240, 240, 240, 255), stop: .95 rgba(240, 240, 240, 255), stop: 1 #ebebeb);
-color:#333;
-}
-
-QDialog#OpenURIDialog QPushButton#selectFileButton:pressed {
-border:1px solid #9e9e9e;
-}
-
-/**************************** SIGN/ VERIFY MESSAGE DIALOG *******************************/
-
-/* QDialog#SignVerifyMessageDialog QPushButton#addressBookButton_SM { /* Address Book Button */
-/* QDialog#SignVerifyMessageDialog QPlainTextEdit { /* Message Signing Text */
-/* QDialog#SignVerifyMessageDialog QPushButton#pasteButton_SM { /* Paste Button */
-/* QDialog#SignVerifyMessageDialog QLineEdit:!focus { /* Font Hack */
-/* QDialog#SignVerifyMessageDialog QPushButton#copySignatureButton_SM { /* Copy Button */
-/* QDialog#SignVerifyMessageDialog QPushButton#clearButton_SM { /* Clear Button */
-/* QDialog#SignVerifyMessageDialog QPushButton#addressBookButton_VM { /* Verify Message - Address Book Button */
-/* QDialog#SignVerifyMessageDialog QPushButton#clearButton_VM { /* Verify Message - Clear Button */
-
-/**************************** SEND AND RECEIVE ADDRESSES DIALOG *****************************/
-
-QWidget#AddressBookPage {
-background-color:#F8F6F6;
-}
-
-/* QWidget#AddressBookPage QPushButton#newAddress { /* New Address Button */
-/* QWidget#AddressBookPage QPushButton#copyAddress { /* Copy Address Button */
-/* QWidget#AddressBookPage QPushButton#deleteAddress { /* Delete Address Button */
-
-QWidget#AddressBookPage QTableView { /* Address Listing */
-font-size:12px;
-}
-
-QWidget#AddressBookPage QHeaderView::section { /* Min width for Windows fix */
-min-width:260px;
-}
-
-/**************************** MultiSig Dialog *******************************************/
-
-/* QDialog#MultisigDialog QPushButton { */
-/* QDialog#MultisigDialog QFrame#addressFrame { */
-
-/**************************** Privacy Dialog ********************************************/
-
-
-QWidget#PrivacyDialog QFrame {
-background-color:transparent;
-border:0px solid #000;
-}
-
-QWidget#PrivacyDialog QFrame#labelMintStatus {
-background-color:#eee;
-border: 1px inset gray;
-}
-
-QWidget#PrivacyDialog QLabel {
-border:0px solid #000;
-}
-
-QWidget#PrivacyDialog QLabel#zPIVLabel {
-font-size:14px;
-color:#ffffff;
-background-color:#5c4c7c;
-}
-
-QWidget#PrivacyDialog QLabel#oPIVLabel {
-font-size:14px;
-color:#ffffff;
-background-color:#5c4c7c;
-}
-
-QWidget#PrivacyDialog QPushButton {
-font-size:12px;
-font-weight:normal;
-padding-left:5px;
-padding-right:5px;
-padding-top:1px;
-padding-bottom:1px;
-height: 26px;
-margin: 2px;
-}
-
-QWidget#PrivacyDialog QProgressBar#obfuscationProgress { /* Obfuscation Completion */
-border: 1px solid #818181;
-border-radius: 1px;
-margin-right:43px;
-text-align: right;
-color:#818181;
-}
-
-QWidget#PrivacyDialog QProgressBar#obfuscationProgress::chunk {
-background-color: #382f44;
-width:1px;
-}
-
-/**************************** SETTINGS MENU *********************************************/
-
-/* Encrypt Wallet and Change Passphrase Dialog */
-QDialog#AskPassphraseDialog QLabel#passLabel1, QDialog#AskPassphraseDialog QLabel#passLabel2, QDialog#AskPassphraseDialog QLabel#passLabel3 {
-qproperty-alignment: 'AlignVCenter | AlignRight';
-}
-
-/* Options Dialog */
-QDialog#OptionsDialog QValueComboBox, QDialog#OptionsDialog QSpinBox {
-margin-top:5px;
-margin-bottom:5px;
-}
-
-QDialog#OptionsDialog QValidatedLineEdit, QDialog#OptionsDialog QValidatedLineEdit:disabled, QDialog#OptionsDialog QLineEdit, QDialog#OptionsDialog QLineEdit:disabled {
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-height:20px;
-margin-top:0px;
-margin-bottom:0px;
-padding-top:1px;
-padding-bottom:1px;
-}
-
-QDialog#OptionsDialog > QLabel {
-qproperty-alignment: 'AlignVCenter';
-min-height:20px;
-}
-
-QDialog#OptionsDialog QWidget#tabDisplay QValueComboBox {
-margin-top:0px;
-margin-bottom:0px;
-}
-
-QDialog#OptionsDialog QLabel#label_3 { /* Translations Missing? Label */
-qproperty-alignment: 'AlignVCenter | AlignCenter';
-color:#818181;
-padding-bottom:8px;
-}
-
-QDialog#OptionsDialog QCheckBox {
-min-height:20px;
-}
-
-QDialog#OptionsDialog QCheckBox#displayAddresses {
-min-height:33px;
-}
-
-QDialog#OptionsDialog QLabel#labelStakeSplitThresholdText {
-font-size:16px;
-}
-
-/**************************** TOOLS MENU ************************************************/
-
-QDialog#RPCConsole QWidget#tab_info QLabel#label_11, QDialog#RPCConsole QWidget#tab_info QLabel#label_10 { /* Margin between Network and Block Chain headers */
-qproperty-alignment: 'AlignBottom';
-min-height:25px;
-min-width:180px;
-}
-
-QDialog#RPCConsole QWidget#tab_peers QLabel#peerHeading { /* Peers Info Header */
-color:#382f44;
-}
-
-QDialog#RPCConsole QTableView#peerWidget::item { /* Peers Table Items */
-color:#333;
-}
-
-QDialog#RPCConsole QPushButton#openDebugLogfileButton {
-max-width:60px;
-}
-
-QDialog#RPCConsole QTextEdit#messagesWidget { /* Console Messages Window */
-border:0;
-background-color:#fcfcfc;
-color:#333;
-}
-
-QDialog#RPCConsole QLineEdit#lineEdit { /* Console Input */
-margin-right:5px;
-}
-
-QDialog#RPCConsole QPushButton#clearButton { /* Console Clear Button */
-background-color:transparent;
-padding-left:10px;
-padding-right:10px;
-}
-
-QDialog#RPCConsole .QGroupBox #line { /* Network In Line */
-background-color:#5c4c7c;
-}
-
-QDialog#RPCConsole .QGroupBox #line_2 { /* Network Out Line */
-background:#fff;
-}
-
-/**************************** HELP MENU *************************************************/
-
-/* Command Line Options Dialog */
-QDialog#HelpMessageDialog QScrollArea * {
-background-color:#fff;
-}
-
-QDialog#HelpMessageDialog QScrollBar:vertical, QDialog#HelpMessageDialog QScrollBar:horizontal {
-border:0;
-}
-
-/* About Pivx Dialog */
-QDialog#AboutDialog QLabel#label, QDialog#AboutDialog QLabel#copyrightLabel, QDialog#AboutDialog QLabel#label_2 { /* About Pivx Contents */
-margin-left:10px;
-}
-
-QDialog#AboutDialog QLabel#label_2 { /* Margin for About Pivx text */
-margin-right:10px;
-}
-
-/* Edit Address Dialog */
-QDialog#EditAddressDialog QLabel {
-qproperty-alignment: 'AlignVCenter | AlignRight';
-min-height:27px;
-font-weight:normal;
-padding-right:5px;
-}
-
-/* Header design for ALL tabs/pages *****************************************************/
-/* Horizontal lines */
-QFrame[frameShape="4"] { /* QFrame::HLine == 0x0004 */
-border:1px solid #372f44;
-}
-
-/* Headers */
-QLabel#labelOverviewHeaderLeft {
-font-weight:bold;
-font-size:20px;
-background-color:#ffffff;
-}
-
-QLabel#labelOverviewHeaderRight {
-qproperty-alignment: 'AlignVCenter | AlignRight';
-background-image: url(':/images/pivx_logo_horizontal');
-background-repeat: no-repeat;
-}
-
-QWidget .QFrame#frame_Header { /* Header with Page-Title and PIVX-image */
-min-width:400px;
-background-color:#ffffff;
-}
-
-QWidget .QFrame#frame_BG { /* Background */
-min-width:400px;
-background-color:#f8f6f6;
-}
-
-/**************************** OVERVIEW SCREEN *******************************************/
-
-QWidget .QFrame#frame_Space { /* Space between Header and Content */
-min-width:400px;
-background-color:#f8f6f6;
-}
-
-QWidget .QFrame#frame_Content { /* Actual Content */
-min-width:400px;
-background-color:#f8f6f6;
-}
-
-QWidget .QFrame#frame_Balances { /* Upper left side */
-min-width:400px;
-background-color:#ffffff;
-}
-
-QWidget .QFrame#frame_ZerocoinBalances { /* Lower left side */
-min-width:400px;
-background-color:#ffffff;
-}
-
-QWidget .QFrame#frame_CombinedBalances { /* Lower left side */
-min-width:400px;
-background-color:#ffffff;
-}
-
-QWidget .QFrame#frame_RecentTransactions { /* Right side */
-min-width:400px;
-background-color:#ffffff;
-}
-
-QWidget .QFrame#frame_Balances > .QLabel {
-min-width:190px;
-font-weight:normal;
-/* min-height:30px; */
-}
-
-QWidget .QFrame#frame_Balances .QLabel#label_5 { /* PIV Balances Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-background-color:transparent;
-color:#382F44;
-font-weight:bold;
-font-size:14px;
-margin-right:5px;
-padding-right:5px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelWalletStatus { /* Wallet Sync Status */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-margin-left:3px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelSpendable { /* Spendable Header */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-margin-left:18px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelWatchonly { /* Watch-only Header */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-margin-left:16px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelBalanceText { /* Available Balance Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelBalance { /* Available Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#5c4c7c;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelWatchAvailable { /* Watch-only Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-margin-left:16px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelPendingText { /* Pending Balance Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelUnconfirmed { /* Pending Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#5c4c7c;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelWatchPending { /* Watch-only Pending Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-margin-left:16px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelImmatureText { /* Immature Balance Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelImmature { /* Immature Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#5c4c7c;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelWatchImmature { /* Watch-only Immature Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-margin-left:16px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelTotalText { /* Total Balance Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelTotal { /* Total Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#5c4c7c;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelWatchTotal { /* Watch-only Total Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-margin-left:16px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelLockedBalanceText { /* Available zPIV Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelLockedBalance { /* Available zPIV Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#5c4c7c;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_Balances .QLabel#labelWatchLocked { /* Available zPIV Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-margin-left:16px;
-}
-
-/* Zerocoin additions start here ***********************************************/
-
-QWidget .QFrame#frame_ZerocoinBalances .QLabel#label_5z_3 { /* Zerocoin Balance Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-background-color:transparent;
-color:#382F44;
-font-weight:bold;
-font-size:14px;
-margin-right:5px;
-padding-right:5px;
-}
-
-QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceText { /* Available zPIV Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalance { /* Available zPIV Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#5c4c7c;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceUnconfirmedText { /* Unconfirmed zPIV Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceUnconfirmed { /* Unconfirmed zPIV Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#5c4c7c;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceMatureText { /* Mature zPIV Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceMature { /* Mature zPIV Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#5c4c7c;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceImmatureText { /* Immature zPIV Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceImmature { /* Immature zPIV Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#5c4c7c;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_CombinedBalances .QLabel#label_5z { /* Combined Balance Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-background-color:transparent;
-color:#382F44;
-font-weight:bold;
-font-size:14px;
-margin-right:5px;
-padding-right:5px;
-}
-
-QWidget .QFrame#frame_CombinedBalances .QLabel#labelBalanceTextz { /* Available PIV Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_CombinedBalances .QLabel#labelBalancez { /* Available PIV Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:26px;
-font-weight:normal;
-color:#372f44;
-}
-
-QWidget .QFrame#frame_CombinedBalances .QLabel#labelzBalanceTextz { /* Available zPIV Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_CombinedBalances .QLabel#labelzBalancez { /* Available zPIV Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
-font-weight:bold;
-color:#5c4c7c;
-margin-left:0px;
-}
-
-QWidget .QFrame#frame_CombinedBalances .QLabel#labelTotalTextz { /* Available total Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-color:#372f44;
-margin-right:5px;
-padding-right:5px;
-font-weight:bold;
-font-size:12px;
-}
-
-QWidget .QFrame#frame_CombinedBalances .QLabel#labelTotalz { /* Available total Balance */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:26px;
-font-weight:normal;
-color:#372f44;
-}
-
-/**************************** RECENT TRANSACTIONS ***************************************/
-
-QWidget .QFrame#frame_RecentTransactions { /* Transactions Widget */
-min-width:410px;
-min-height:100px;
-margin-left:0;
-margin-top:0;
-}
-
-QWidget .QFrame#frame_RecentTransactions .QLabel#label_4 { /* Recent Transactions Label */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:180px;
-background-color:transparent;
-color:#382F44;
-font-weight:bold;
-font-size:14px;
-margin-right:5px;
-padding-right:5px;
-}
-
-QWidget .QFrame#frame_RecentTransactions .QLabel#labelTransactionsStatus { /* Recent Transactions Sync Status */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-margin-left:3px;
-}
-
-QWidget .QFrame#frame_RecentTransactions QListView { /* Transaction List */
-font-weight:normal;
-font-size:12px;
-max-width:369px;
-margin-top:12px;
-margin-left:0px; /* CSS Voodoo - set to -66px to hide default transaction icons */
-}
-
-/**************************** SEND DIALOG ***********************************************/
-
-QDialog#SendCoinsDialog {
-background-color:#fff;
-}
-
-QDialog#SendCoinsDialog .QFrame#frameCoinControl { /* Coin Control Section */
-background-color:#ffffff;
-}
-
-QDialog#SendCoinsDialog .QFrame#frameFee { /* Coin Control Section */
-background-color:#ffffff;
-}
-
-QDialog#SendCoinsDialog .QFrame#frame_Send { /* Coin Control Section */
-background-color:#ffffff;
-margin-bottom:6px;
-}
-
-QDialog#SendCoinsDialog .QFrame#frameCoinControl { /* Coin Control Section */
-/* background-color:#ffff00; */
-}
-
-QDialog#SendCoinsDialog .QFrame#frameCoinControl > .QLabel { /* Default Font Color and  Size */
-font-weight:normal;
-}
-
-QDialog#SendCoinsDialog .QFrame#frameCoinControl .QPushButton#pushButtonCoinControl { /* Coin Control Inputs Button */
-padding-left:10px;
-padding-right:10px;
-min-height:25px;
-}
-
-QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlFeatures { /* Coin Control Header */
-qproperty-alignment: 'AlignVCenter | AlignLeft';
-min-width:160px;
-background-color:transparent;
-color:#382F44;
-font-weight:bold;
-font-size:14px;
-margin-right:5px;
-padding-right:5px;
-}
-
-QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl { /* Coin Control Inputs */
-}
-
-QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl > .QLabel { /* Coin Control Inputs Labels */
-padding:2px;
-}
-
-/* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QCheckBox#checkBoxCoinControlChange { /* Custom Change Label */
-/* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QValidatedLineEdit#lineEditCoinControlChange { /* Custom Change Address */
-/* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QValidatedLineEdit#lineEditCoinControlChange:!focus { /* Custom Change Address */
-/* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLineEdit#splitBlockLineEdit { */
-/* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLineEdit#splitBlockLineEdit:!focus { /* TX Splitter */
-
-QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlChangeLabel { /* Custom Change Address Validation Label */
-font-weight:normal;
-}
-
-QDialog#SendCoinsDialog .QScrollArea#scrollArea .QWidget#scrollAreaWidgetContents { /* Send To Widget */
-background-color:#ffffff;
-}
-
-
-
-QDialog#SendCoinsDialog .QCheckBox#checkUseObfuscation { /* Obfuscation Checkbox */
-color:#616161;
-font-weight:bold;
-/*background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));*/
-border-radius:5px;
-padding-top:20px;
-padding-bottom:18px;
-}
-
-QDialog#SendCoinsDialog .QCheckBox#checkSwiftTX { /* SwiftTX Checkbox */
-color:#616161;
-font-weight:bold;
-/*background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));*/
-border-radius:5px;
-padding-top:20px;
-padding-bottom:18px;
-margin-left:10px;
-margin-right:20px;
-}
-
-/* This QLabel uses name = "label" which conflicts with Address Book -> New Address */
-/* To maximize backwards compatibility this formatting has been removed */
-
-QDialog#SendCoinsDialog QLabel#label {
-min-height:27px;
-}
-
-QDialog#SendCoinsDialog QLabel#labelBalance {
-margin-left:0px;
-padding-left:0px;
-color:#333333;
-min-height:27px;
-}
-
-/**************************** SEND COINS ENTRY ******************************************/
-
-QStackedWidget#SendCoinsEntry .QFrame#SendCoins > .QLabel { /* Send Coin Entry Labels */
-min-width:10px;
-font-weight:bold;
-min-height:25px;
-margin-right:5px;
-padding-right:5px;
-}
-
-/* QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo { /* Pay To Input Field */
-/* QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo:!focus { /* Pay To Input Field */
-/* QStackedWidget#SendCoinsEntry .QToolButton { /* Pay To Custom ToolButton */
-/* QStackedWidget#SendCoinsEntry .QToolButton:hover { /* Pay To Custom ToolButton */
-/* QStackedWidget#SendCoinsEntry .QToolButton:focus { /* Pay To Custom ToolButton */
-/* QStackedWidget#SendCoinsEntry .QToolButton:pressed { /* Pay To Custom ToolButton */
-/* QStackedWidget#SendCoinsEntry .QToolButton#addressBookButton { /* Address Book Button */
-/* QStackedWidget#SendCoinsEntry .QToolButton#pasteButton { */
-/* QStackedWidget#SendCoinsEntry .QToolButton#deleteButton { */
-/* QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel { /* Pay To Input Field */
-/* QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel:!focus { /* Pay To Input Field */
-
-/**************************** COIN CONTROL POPUP ****************************************/
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlQuantityText { /* Coin Control Quantity Label */
-min-height:30px;
-padding-left:15px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlQuantity { /* Coin Control Quantity */
-min-height:30px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlBytesText { /* Coin Control Bytes Label */
-padding-left:15px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlBytes { /* Coin Control Bytes */
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlAmountText { /* Coin Control Amount Label */
-min-height:30px;
-padding-left:15px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlAmount { /* Coin Control Amount */
-min-height:30px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlPriorityText { /* Coin Control Priority Label */
-padding-left:15px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlPriority { /* Coin Control Priority */
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlFeeText { /* Coin Control Fee Label */
-min-height:30px;
-padding-left:15px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlFee { /* Coin Control Fee */
-min-height:30px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlLowOutputText { /* Coin Control Low Output Label */
-padding-left:15px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlLowOutput { /* Coin Control Low Output */
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlAfterFeeText { /* Coin Control After Fee Label */
-min-height:30px;
-padding-left:15px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlAfterFee { /* Coin Control After Fee */
-min-height:30px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlChangeText { /* Coin Control Change Label */
-padding-left:15px;
-}
-
-QDialog#CoinControlDialog .QLabel#labelCoinControlChange { /* Coin Control Change */
-
-}
-
-QDialog#CoinControlDialog .QFrame#frame .QPushButton#pushButtonSelectAll { /* (un)select all button */
-padding-left:10px;
-padding-right:10px;
-min-height:25px;
-}
-
-QDialog#CoinControlDialog .QFrame#frame .QPushButton#pushButtonToggleLock { /* Toggle lock state button */
-padding-left:10px;
-padding-right:10px;
-min-height:25px;
-}
-
-QDialog#CoinControlDialog .QDialogButtonBox#buttonBox QPushButton { /* Coin Control 'OK' button */
-}
-
-QDialog#CoinControlDialog .QFrame#frame .QRadioButton#radioTreeMode { /* Coin Control Tree Mode Selector */
-color:#818181;
-background-color:transparent;
-}
-
-QDialog#CoinControlDialog .QFrame#frame .QRadioButton#radioListMode { /* Coin Control List Mode Selector */
-color:#818181;
-background-color:transparent;
-}
-
-QDialog#CoinControlDialog QHeaderView::section:first { /* Bug Fix: the number "1" displays in this table for some reason... */
-color:transparent;
-}
-
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget { /* Coin Control Widget Container */
-outline:0;
-background-color:#ffffff;
-border:1px solid #333;
-}
-
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {
-}
-
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:selected { /* Coin Control Item (selected) */
-background-color:#5c4c7c;
-color:#fff;
-}
-
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:checked { /* Coin Control Item (checked) */
-background-color:#f7f7f7;
-color:#fff;
-}
-
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:selected { /* Coin Control Branch Icon */
-background-image: url(':/images/qtreeview_selected');
-background-repeat:no-repeat;
-background-position:center;
-background-color:#f7f7f7;
-color:#333;
-}
-
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:checked { /* Coin Control Branch Icon */
-background-image: url(':/images/qtreeview_selected');
-background-repeat:no-repeat;
-background-position:center;
-background-color:#f7f7f7;
-color:#333;
-}
-
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::seperator {
-
-}
-
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::indicator { /* Coin Control Widget Checkbox */
-
-}
-
-QDialog#ZPivControlDialog .QTreeWidget#treeWidget { /* zPIV Control Widget Container */
-outline:0;
-background-color:#ffffff;
-border:1px solid #333;
-}
-
-/**************************** RECEIVE COINS *********************************************/
-
-QWidget#ReceiveCoinsDialog {
-background-color:#fff;
-}
-
-QWidget#ReceiveCoinsDialog .QFrame#frame {
-background-color:#ffffff;
-}
-
-QWidget#ReceiveCoinsDialog .QFrame#frame2 {
-background-color:#ffffff;
-}
-
-QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLabel { /* Receive Coin Labels */
-min-width:10px;
-font-weight:bold;
-min-height:25px;
-margin-right:5px;
-padding-right:5px;
-}
-
-/* QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLineEdit { /* Receive Coin LineEdits */
-/* QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLineEdit:!focus { /* Receive Coin LineEdits */
-
-QWidget#ReceiveCoinsDialog .QFrame#frame QPushButton { /* Clear Button */
-padding-left:10px;
-padding-right:10px;
-}
-
-QWidget#ReceiveCoinsDialog .QFrame#frame QPushButton:pressed {
-border:1px solid #9e9e9e;
-}
-
-QWidget#ReceiveCoinsDialog .QFrame#frame2 QPushButton { /* Clear Button */
-padding-left:10px;
-padding-right:10px;
-}
-
-QWidget#ReceiveCoinsDialog .QFrame#frame2 QPushButton:pressed {
-border:1px solid #9e9e9e;
-}
-
-QWidget#ReceiveCoinsDialog .QFrame#frame .QLabel#label_6 { /* Requested Payments History Label */
-color:#382f44;
-font-weight:bold;
-font-size:14px;
-}
-
-/**************************** RECEIVE COINS DIALOG **************************************/
-
-QDialog#ReceiveRequestDialog QTextEdit { /* Contents of Receive Coin Dialog */
-border:1px solid #d7d7d7;
-}
-
-/**************************** TRANSACTIONS PAGE *****************************************/
-
-TransactionView QLineEdit { /* Address Filter */
-margin-bottom:2px;
-margin-right:1px;
-min-width:111px;
-text-align:center;
-}
-
-TransactionView QComboBox {
-margin-bottom:1px;
-margin-right:1px;
-}
-
-QLabel#transactionSumLabel { /* Example of setObjectName for widgets without name */
-color:#333333;
-font-weight:bold;
-}
-
-QLabel#transactionSum { /* Example of setObjectName for widgets without name */
-color:#333333;
-}
-
-/**************************** TRANSACTION DETAILS DIALOG ********************************/
-
-QDialog#TransactionDescDialog QTextEdit { /* Contents of Receive Coin Dialog */
-border:1px solid #d7d7d7;
-}
-
-/**************************** PRIVACY PAGE *****************************************/
-/* QDialog#PrivacyDialog */
-/* QWidget#PrivacyDialog */
-
-QWidget#PrivacyDialog .QFrame[frameShape="4"] { /* QFrame::HLine == 0x0004 */
-border:1px solid #372f44;
-}
-
-QWidget#PrivacyDialog .QFrame#frame_Content {
-background-color:#f8f6f6;
-}
-
-QWidget#PrivacyDialog .QFrame#verticalFrameLeft {
-background-color:#ffffff;
-}
-
-QWidget#PrivacyDialog .QFrame#verticalFrameRight {
-background-color:#ffffff;
-}
-
-QWidget#PrivacyDialog .QToolButton {
-margin:2px;
-min-height: 24px;
-min-width: 24px;
-}
-
-/**************************** MASTERNODE LIST *******************************************/
-QWidget#MasternodeList .QFrame#frameList {
-background-color:#ffffff;
-}
-
-
-/********************************* CALENDAR WIDGET **************************************/
-
-QCalendarView {
-border:1px solid #333;
-}
-
-QCalendarWidget QWidget#qt_calendar_navigationbar { /* Calendar widget navigation bar */
-background-color:#5c4c7c;
-font-weight:bold;
-}
-
-QCalendarWidget QAbstractItemView { /* Calendar widget days */
-alternate-background-color:#dedbe5;
-background-color:#fff;
-}
-
-QCalendarWidget QAbstractItemView:enabled { /* Calendar widget weekdays in month */
-color:#333;
-}
-
-QCalendarWidget QAbstractItemView:disabled { /* Calendar widget days not in month */
-color:#818181;
-}
-
-QWidget#GovernancePage .QFrame#frame_Content {
     background-color:#ffffff;
-}
-
-QWidget#GovernancePage .ProposalFrame {
-    border-radius:5px;
-    margin:2px;
-    max-height:250px;
-}
-
-QWidget#GovernancePage .ProposalFrame#proposalFrame {
-    background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #9179c7, stop: 1 #b396f6);
-    border:1px solid #b396f6;
-}
-
-QWidget#GovernancePage .ProposalFrame#proposalFramePassing {
-    background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #00cc00, stop: 1 #00ef00);
-    border:1px solid #00ef00;
-}
-
-QWidget#GovernancePage .ProposalFrame#proposalFrameNotEstablished {
-    background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #0080ff, stop: 1 #00a3ff);
-    border:1px solid #00a3ff;
-}
-
-QWidget#GovernancePage .ProposalFrame#proposalFramePassingUnfunded {
-    background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #cccc00, stop: 1 #efef00);
-    border:1px solid #efef00;
-}
-
-QWidget#GovernancePage .ProposalFrame > QLabel#strProposalName, QLabel#strMonthlyPayout, QLabel#strRemainingPaymentCount {
-    font-size:18pt;
-}
-
-QWidget#GovernancePage .ProposalFrame > QLabel#strProposalURL {
-    font-size:14pt;
-}
-
-QWidget#GovernancePage .QScrollArea, .QWidget#scrollAreaWidgetContents {
+    border-top:0px solid #000;
+    margin:0;
+    padding:0;
+    }
+    
+    QStatusBar {
+    background-color:#ffffff;
+    }
+    
+    .QFrame {
+    background-color:transparent;
+    border:0px solid #fff;
+    }
+    
+    QMenuBar {
     background-color:#fff;
-}
-
-QWidget#GovernancePage .QGridLayout#proposalGrid {
-    margin-right:35px!important;
-    padding-right:35px!important;
-}
+    }
+    
+    QMenuBar::item {
+    background-color:#fff;
+    color:#333;
+    }
+    
+    QMenuBar::item:selected {
+    background-color:#f8f6f6;
+    }
+    
+    QMenu {
+    background-color:#f8f6f6;
+    }
+    
+    QMenu::item {
+    color:#333;
+    }
+    
+    QMenu::item:selected {
+    background-color:#f2f0f0;
+    color:#333;
+    }
+    
+    QToolBar {
+    background-color: qlineargradient(y1:0, y2: 1, stop: 0 #004d00, stop: 0.75 #004d00, stop: 0.99 #ffffff, stop: 1 #ffffff);
+    border:0px solid #333;
+    padding:1;
+    margin:0;
+    width: 70px;
+    }
+    
+    QToolBar > QToolButton {
+    Alignment: left;
+    background-color: #004d00;
+    selection-background-color:transparent;
+    border:0.5px solid #888;
+    border-left: 0px;
+    border-right: 0px;
+    border-top: 0px;
+    min-height:2.5em;
+    padding: 0em 0em;
+    font-size: 11px;
+    color:#aaa;
+    width: 80px;
+    height: 60px;
+    }
+    
+    QToolBar > QToolButton:checked {
+    background-color: qlineargradient(x1:0, x2: 1, stop: 0 #ffffff, stop: 0.07 #ffffff, stop: 0.0701 #004d00, stop: 1 #004d00);
+    color:#fff;
+    }
+    
+    /* QToolBar > QToolButton:hover:!selected { */
+    QToolBar > QToolButton:hover {
+    background-color: qlineargradient(x1:0, x2: 1, stop: 0 #ffffff, stop: 0.07 #ffffff, stop: 0.0701 #004d00, stop: 1 #004d00);
+    color:#fff;
+    }
+    
+    QToolBar > QToolButton#ToolbarSpacer:hover:!selected {
+    background-color: #004d00; /* Do not highlight placeholder on hover */
+    }
+    
+    QToolBar > QToolButton:pressed {
+    background-color: qlineargradient(x1:0, x2: 1, stop: 0 #00a300, stop: 0.07 #00a300, stop: 0.0701 #004d00, stop: 1 #004d00);
+    color:#fff;
+    }
+    
+    QMessageBox {
+    background-color:#fff;
+    }
+    
+    QProgressBar {
+    color: #AAAAAA;
+    border:0px solid grey;
+    border-radius:5px;
+    background-color:transparent;
+    padding-left:0px;
+    padding-right:0px;
+    }
+    
+    QProgressBar::chunk {
+    background-color:#4c7b4c;
+    width: 20px;
+    }
+    
+    QLabel#progressBarLabel {
+    background-color:transparent;
+    color: #304530;
+    padding-left:5px;
+    padding-right:5px;
+    }
+    
+    QTabWidget {
+    background-color:#f2f2f2;
+    }
+    
+    QTabWidget::pane {
+    background-color:#f2f2f2;
+    border:1px solid #c2c2c2;
+    }
+    
+    QTabBar {
+    background-color:#f2f2f2;
+    color:#333;
+    }
+    
+    QTabBar::tab:hover:!selected {
+    background-color:#dedbe5;
+    }
+    
+    QWidget {
+    selection-background-color:#4c7b4c; /* Object highlight color */
+    selection-color:#fff;
+    outline:0; /* Remove Annoying Focus Rectangle */
+    }
+    
+    QGroupBox {
+    background-color:#fcfcfc;
+    color:#333;
+    }
+    
+    QToolTip {
+    background-color:#dedbe5;
+    color:#333;
+    }
+    
+    /****************************************************************************************/
+    
+    QLabel { /* Base Text Size & Color */
+    font-size:12px;
+    color:#333333;
+    }
+    
+    .QRadioButton { /* Radio Button Labels */
+    color:#333333;
+    }
+    
+    .QCheckBox { /* Checkbox Labels */
+    color:#333333;
+    }
+    
+    .QCheckBox:hover {
+    }
+    
+    .QValidatedLineEdit, .QLineEdit, .QTextEdit { /* Text Entry Fields */
+    font-size:12px;
+    min-height:25px;
+    outline:0;
+    padding:3px;
+    border:0px;
+    color:#333;
+    background-color:#f2f2f2;
+    }
+    
+    .QValidatedLineEdit:!focus {
+    color:#4c7b4c;
+    background-color:#e7e7e7;
+    }
+    
+    .QLineEdit:!focus {
+    color:#4c7b4c;
+    background-color:#e7e7e7;
+    }
+    
+    .QTextEdit:!focus {
+    color:#4c7b4c;
+    background-color:#e7e7e7;
+    }
+    
+    /* .QValidatedLineEdit:checked, .QLineEdit:checked */
+    
+    .QValidatedLineEdit:disabled, .QLineEdit:disabled, .QTextEdit:disabled {
+    color: #4c7b4c;
+    background-color:#f2f2f2;
+    }
+    
+    .QPlainTextEdit {
+    background-color:#f2f2f2;
+    }
+    
+    /***************************** Global Qt Objects ***********************************************************/
+    
+    QPushButton { /* Global Button Style */
+    background-color: #4c7b4c;
+    border-width: 1px;
+    border-style: outset;
+    border-color: #304530;
+    border-radius: 2px;
+    color:#ffffff;
+    font-size:12px;
+    font-weight:bold;
+    padding-left:25px;
+    padding-right:25px;
+    padding-top:1px;
+    padding-bottom:1px;
+    height: 26px;
+    margin: 2px;
+    }
+    
+    QPushButton:hover {
+    background-color: qlineargradient(y1:0, y2: 1, stop: 0 #ffffff, stop: 0.1 #ffffff, stop: 0.101 #5ca35c, stop: 0.9 #5ca35c, stop: 0.901 #ffffff, stop: 1 #ffffff);
+    }
+    
+    QPushButton:focus {
+    /* border:none; */
+    /* outline:none; */
+    }
+    
+    QPushButton:pressed {
+    background-color: #4c7b4c;
+    border:1px solid #000000;
+    background-color: qlineargradient(y1:0, y2: 1, stop: 0 #00ff00, stop: 0.1 #00ff00, stop: 0.101 #5ca35c, stop: 0.9 #5ca35c, stop: 0.901 #00ff00, stop: 1 #00ff00);
+    }
+    
+    /* Special handling for statusbar-icons (which are partly QPushButtons) */
+    QPushButton#labelEncryptionIcon, QPushButton#labelConnectionsIcon, QPushButton#labelAutoMintIcon {
+    border: 0px;
+    padding-left:0px;
+    padding-right:0px;
+    padding-top:0px;
+    padding-bottom:0px;
+    margin: 0px;
+    }
+    
+    /* QSpinBox::up-arrow:hover */
+    /* QSpinBox::down-arrow:hover */
+    
+    QSpinBox::up-button:hover {
+    background-color: #f2f2f2;
+    }
+    
+    QSpinBox::down-button:hover {
+    background-color: #f2f2f2;
+    }
+    
+    QComboBox { /* Dropdown Menus */
+    border:1px solid #4c7b4c;
+    padding: 3px 5px 3px 5px;
+    background:#fcfcfc;
+    min-height:25px;
+    color:#818181;
+    }
+    
+    QComboBox:checked {
+    background:#f2f2f2;
+    }
+    
+    QComboBox:editable {
+    background:#304530;
+    color:#616161;
+    border:0px solid transparent;
+    }
+    
+    QComboBox::drop-down {
+    width:25px;
+    border:0px;
+    }
+    
+    QComboBox::down-arrow {
+    border-image: url(':/images/downArrow') 0 0 0 0 stretch stretch;
+    }
+    
+    QComboBox QListView {
+    background:#fff;
+    border:1px solid #333;
+    padding-right:1px;
+    padding-left:1px;
+    color:#818181;
+    }
+    
+    QComboBox QAbstractItemView::item {
+    margin:4px;
+    }
+    
+    QComboBox::item {
+    color:#818181;
+    }
+    
+    QComboBox::item:alternate {
+    background:#fff;
+    }
+    
+    QComboBox::item:selected {
+    border:0px solid transparent;
+    background:#f2f2f2;
+    }
+    
+    QComboBox::indicator {
+    background-color:transparent;
+    selection-background-color:transparent;
+    color:transparent;
+    selection-color:transparent;
+    }
+    
+    QAbstractSpinBox {
+    padding: 3px 5px 3px 5px;
+    background:#fcfcfc;
+    font-size:12px;
+    min-height:25px;
+    outline:0;
+    padding:3px;
+    border:0px;
+    color:#333;
+    background-color:#f2f2f2;
+    }
+    
+    QAbstractSpinBox:!focus {
+    color:#4c7b4c;
+    background-color:#e7e7e7;
+    }
+    
+    QAbstractSpinBox::up-button {
+    subcontrol-origin: border;
+    subcontrol-position: top right;
+    width:21px;
+    background:#e7e7e7; /* Remove this to get 3D rendered buttons */
+    padding-right:1px;
+    padding-left:5px;
+    padding-top:2px;
+    }
+    
+    QAbstractSpinBox::up-arrow {
+    image:url(':/images/upArrow_small');
+    }
+    
+    QAbstractSpinBox::down-button {
+    subcontrol-origin: border;
+    subcontrol-position: bottom right;
+    width:21px;
+    background:#e7e7e7; /* Remove this to get 3D rendered buttons */
+    padding-right:1px;
+    padding-left:5px;
+    padding-bottom:2px;
+    }
+    
+    QAbstractSpinBox::down-arrow {
+    image:url(':/images/downArrow_small');
+    }
+    
+    QValueComboBox {
+    padding: 3px 5px 3px 5px;
+    background:#fcfcfc;
+    font-size:12px;
+    min-height:25px;
+    outline:0;
+    padding:3px;
+    border:0px;
+    color:#333;
+    background-color:#f2f2f2;
+    }
+    
+    QValueComboBox:!focus {
+    color:#4c7b4c;
+    background-color:#e7e7e7;
+    }
+    
+    /****************************************************************************************/
+    
+    QHeaderView { /* Table Header */
+    background-color:transparent;
+    outline:0;
+    }
+    
+    QHeaderView::section { /* Table Header Sections */
+    qproperty-alignment:center;
+    background-color: #4c7b4c;
+    color:#fff;
+    min-height:25px;
+    font-weight:bold;
+    font-size:11px;
+    border:0;
+    border-right:1px solid #fff;
+    padding-left:5px;
+    padding-right:5px;
+    padding-top:2px;
+    padding-bottom:2px;
+    }
+    
+    QHeaderView::down-arrow {
+        image: url(':/images/downArrow_small_white');
+    }
+    
+    QHeaderView::up-arrow {
+        image: url(':/images/upArrow_small_white');
+    }
+    
+    QHeaderView::section:last {
+    border-right:0;
+    }
+    
+    .QScrollArea {
+    background:transparent;
+    border:0;
+    }
+    
+    .QTableView { /* Table - has to be selected as a class otherwise it throws off QCalendarWidget */
+    background:transparent;
+    border:1px solid #333;
+    }
+    
+    QTableView::item { /* Table Item */
+    background-color:#fcfcfc;
+    font-size:12px;
+    }
+    
+    QTableView::item:selected { /* Table Item Selected */
+    background-color:#4c7b4c;
+    color:#fff;
+    }
+    
+    QTableWidget { /* Table Background */
+    background-color: #fcfcfc;
+    alternate-background-color: yellow;
+    border:1px solid #333;
+    }
+    
+    QTableWidget:focus, QTableView, QTableView:focus { /* Remove focus outline */
+    outline:0;
+    background:transparent;
+    }
+    
+    QTreeWidget { /* Tree Background */
+    background-color:#fcfcfc;
+    alternate-background-color:#f2f2f2;
+    color:#333;
+    }
+    
+    QScrollBar { /* Scroll Bar */
+    
+    }
+    
+    QScrollBar:vertical { /* Vertical Scroll Bar Attributes */
+    border:0;
+    background:#4c7b4c;
+    width:18px;
+    margin:18px 0px 18px 0px;
+    }
+    
+    QScrollBar:horizontal { /* Horizontal Scroll Bar Attributes */
+    border:0;
+    background:#4c7b4c;
+    height:18px;
+    margin:0px 18px 0px 18px;
+    }
+    
+    QScrollBar::handle:vertical { /* Scroll Bar Slider - vertical */
+    background:#4c7b4c;
+    min-height:10px;
+    }
+    
+    QScrollBar::handle:vertical:pressed { /* Scroll Bar Slider - vertical */
+    background:#7ac77a;
+    min-height:10px;
+    }
+    
+    QScrollBar::handle:horizontal { /* Scroll Bar Slider - horizontal */
+    background:#4c7b4c;
+    min-width:10px;
+    }
+    
+    QScrollBar::handle:horizontal:pressed { /* Scroll Bar Slider - horizontal */
+    background:#7ac77a;
+    min-width:10px;
+    }
+    
+    QScrollBar::add-page, QScrollBar::sub-page { /* Scroll Bar Background */
+    background:#F8F6F6;
+    }
+    
+    QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical, QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal { /* Define Arrow Button Dimensions */
+    background-color:#F8F6F6;
+    border: 1px solid #f2f0f0;
+    width:16px;
+    height:16px;
+    }
+    
+    QScrollBar::add-line:vertical:pressed, QScrollBar::sub-line:vertical:pressed, QScrollBar::add-line:horizontal:pressed, QScrollBar::sub-line:horizontal:pressed {
+    background-color:#e0e0e0;
+    }
+    
+    QScrollBar::sub-line:vertical { /* Vertical - top button position */
+    subcontrol-position:top;
+    subcontrol-origin: margin;
+    }
+    
+    QScrollBar::add-line:vertical { /* Vertical - bottom button position */
+    subcontrol-position:bottom;
+    subcontrol-origin: margin;
+    }
+    
+    QScrollBar::sub-line:horizontal { /* Vertical - left button position */
+    subcontrol-position:left;
+    subcontrol-origin: margin;
+    }
+    
+    QScrollBar::add-line:horizontal { /* Vertical - right button position */
+    subcontrol-position:right;
+    subcontrol-origin: margin;
+    }
+    
+    QScrollBar:up-arrow, QScrollBar:down-arrow, QScrollBar:left-arrow, QScrollBar:right-arrow { /* Arrows Icon */
+    width:10px;
+    height:10px;
+    }
+    
+    QScrollBar:up-arrow {
+    background-image: url(':/images/upArrow_small');
+    }
+    
+    QScrollBar:down-arrow {
+    background-image: url(':/images/downArrow_small');
+    }
+    
+    QScrollBar:left-arrow {
+    background-image: url(':/images/leftArrow_small');
+    }
+    
+    QScrollBar:right-arrow {
+    background-image: url(':/images/rightArrow_small');
+    }
+    
+    QSlider::groove:horizontal {
+    border: 1px solid #bbb;
+    background: white;
+    height: 6px;
+    border-radius: 4px;
+    }
+    
+    QSlider::sub-page:horizontal {
+    /* background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #4b864b, stop: 1 #7b67a9); */
+    background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #7ac77a, stop: 1 #98f698);
+    border: 1px solid #333;
+    height: 10px;
+    border-radius: 4px;
+    }
+    
+    QSlider::add-page:horizontal {
+    background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #4c7b4c, stop: 1 #7ac77a);
+    border: 1px solid #333;
+    height: 10px;
+    border-radius: 4px;
+    }
+    
+    QSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #fff, stop:1 #f8f6f6);
+    border: 1px solid #333;
+    width: 18px;
+    height: 18px;
+    margin-top: -6px;
+    margin-bottom: -6px;
+    border-radius: 9px;
+    }
+    
+    QSlider::handle:horizontal:hover {
+    background-color: qradialgradient(cx: 0.5, cy: 0.5, fx: 0.5, fy: 0.5, radius: 0.7, stop: 0 #4c7b4c, stop: 0.7 #ffffff);
+    border: 2px solid #333;
+    width: 16px;
+    height: 16px;
+    margin-top: -6px;
+    margin-bottom: -6px;
+    border-radius: 8px;
+    }
+    
+    /**************************** DIALOG BOXES **********************************************/
+    
+    QDialog {
+    background-color: #fff;
+    }
+    AskPassphraseDialog {
+    background-color: #fff;
+    }
+    
+    
+    QDialog .QTabWidget {
+    border-bottom:1px solid #333;
+    }
+    
+    QDialog .QTabWidget::pane {
+    border: 1px solid #d7d7d7;
+    }
+    
+    QDialog .QTabWidget QTabBar::tab {
+    background-color:#f8f6f6;
+    color:#333;
+    padding-left:10px;
+    padding-right:10px;
+    padding-top:5px;
+    padding-bottom:5px;
+    border-top: 1px solid #d7d7d7;
+    }
+    
+    QDialog .QTabWidget QTabBar::tab:first {
+    border-left: 1px solid #d7d7d7;
+    }
+    
+    QDialog .QTabWidget QTabBar::tab:last {
+    border-right: 1px solid #d7d7d7;
+    }
+    
+    QDialog .QTabWidget QTabBar::tab:selected, QDialog .QTabWidget QTabBar::tab:hover {
+    background-color:#ffffff;
+    color:#333;
+    }
+    
+    QDialog .QTabWidget .QWidget {
+    background-color:#fff;
+    color:#333;
+    }
+    
+    QDialog .QTabWidget .QWidget QAbstractSpinBox {
+    min-height:15px;
+    }
+    
+    QDialog .QTabWidget .QWidget QAbstractSpinBox::down-button {
+    width:15px;
+    }
+    
+    QDialog .QTabWidget .QWidget QAbstractSpinBox::up-button {
+    width:15px;
+    }
+    
+    QDialog .QTabWidget .QWidget QComboBox {
+    min-height:15px;
+    }
+    
+    /**************************** FILE MENU *************************************************/
+    
+    /* Dialog: Open URI */
+    QDialog#OpenURIDialog QLabel#label { /* URI Label */
+    font-weight:bold;
+    }
+    
+    QDialog#OpenURIDialog QPushButton#selectFileButton { /* ... Button */
+    background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
+    border:1px solid #d2d2d2;
+    color:#616161;
+    padding-left:10px;
+    padding-right:10px;
+    }
+    
+    QDialog#OpenURIDialog QPushButton#selectFileButton:hover {
+    background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(240, 240, 240, 255), stop: .95 rgba(240, 240, 240, 255), stop: 1 #ebebeb);
+    color:#333;
+    }
+    
+    QDialog#OpenURIDialog QPushButton#selectFileButton:pressed {
+    border:1px solid #9e9e9e;
+    }
+    
+    /**************************** SIGN/ VERIFY MESSAGE DIALOG *******************************/
+    
+    /* QDialog#SignVerifyMessageDialog QPushButton#addressBookButton_SM { /* Address Book Button */
+    /* QDialog#SignVerifyMessageDialog QPlainTextEdit { /* Message Signing Text */
+    /* QDialog#SignVerifyMessageDialog QPushButton#pasteButton_SM { /* Paste Button */
+    /* QDialog#SignVerifyMessageDialog QLineEdit:!focus { /* Font Hack */
+    /* QDialog#SignVerifyMessageDialog QPushButton#copySignatureButton_SM { /* Copy Button */
+    /* QDialog#SignVerifyMessageDialog QPushButton#clearButton_SM { /* Clear Button */
+    /* QDialog#SignVerifyMessageDialog QPushButton#addressBookButton_VM { /* Verify Message - Address Book Button */
+    /* QDialog#SignVerifyMessageDialog QPushButton#clearButton_VM { /* Verify Message - Clear Button */
+    
+    /**************************** SEND AND RECEIVE ADDRESSES DIALOG *****************************/
+    
+    QWidget#AddressBookPage {
+    background-color:#F8F6F6;
+    }
+    
+    /* QWidget#AddressBookPage QPushButton#newAddress { /* New Address Button */
+    /* QWidget#AddressBookPage QPushButton#copyAddress { /* Copy Address Button */
+    /* QWidget#AddressBookPage QPushButton#deleteAddress { /* Delete Address Button */
+    
+    QWidget#AddressBookPage QTableView { /* Address Listing */
+    font-size:12px;
+    }
+    
+    QWidget#AddressBookPage QHeaderView::section { /* Min width for Windows fix */
+    min-width:260px;
+    }
+    
+    /**************************** MultiSig Dialog *******************************************/
+    
+    /* QDialog#MultisigDialog QPushButton { */
+    /* QDialog#MultisigDialog QFrame#addressFrame { */
+    
+    /**************************** Privacy Dialog ********************************************/
+    
+    
+    QWidget#PrivacyDialog QFrame {
+    background-color:transparent;
+    border:0px solid #000;
+    }
+    
+    QWidget#PrivacyDialog QFrame#labelMintStatus {
+    background-color:#eee;
+    border: 1px inset gray;
+    }
+    
+    QWidget#PrivacyDialog QLabel {
+    border:0px solid #000;
+    }
+    
+    QWidget#PrivacyDialog QLabel#zPIVLabel {
+    font-size:14px;
+    color:#ffffff;
+    background-color:#4c7b4c;
+    }
+    
+    QWidget#PrivacyDialog QLabel#oPIVLabel {
+    font-size:14px;
+    color:#ffffff;
+    background-color:#4c7b4c;
+    }
+    
+    QWidget#PrivacyDialog QPushButton {
+    font-size:12px;
+    font-weight:normal;
+    padding-left:5px;
+    padding-right:5px;
+    padding-top:1px;
+    padding-bottom:1px;
+    height: 26px;
+    margin: 2px;
+    }
+    
+    QWidget#PrivacyDialog QProgressBar#obfuscationProgress { /* Obfuscation Completion */
+    border: 1px solid #818181;
+    border-radius: 1px;
+    margin-right:43px;
+    text-align: right;
+    color:#818181;
+    }
+    
+    QWidget#PrivacyDialog QProgressBar#obfuscationProgress::chunk {
+    background-color: #304530;
+    width:1px;
+    }
+    
+    /**************************** SETTINGS MENU *********************************************/
+    
+    /* Encrypt Wallet and Change Passphrase Dialog */
+    QDialog#AskPassphraseDialog QLabel#passLabel1, QDialog#AskPassphraseDialog QLabel#passLabel2, QDialog#AskPassphraseDialog QLabel#passLabel3 {
+    qproperty-alignment: 'AlignVCenter | AlignRight';
+    }
+    
+    /* Options Dialog */
+    QDialog#OptionsDialog QValueComboBox, QDialog#OptionsDialog QSpinBox {
+    margin-top:5px;
+    margin-bottom:5px;
+    }
+    
+    QDialog#OptionsDialog QValidatedLineEdit, QDialog#OptionsDialog QValidatedLineEdit:disabled, QDialog#OptionsDialog QLineEdit, QDialog#OptionsDialog QLineEdit:disabled {
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-height:20px;
+    margin-top:0px;
+    margin-bottom:0px;
+    padding-top:1px;
+    padding-bottom:1px;
+    }
+    
+    QDialog#OptionsDialog > QLabel {
+    qproperty-alignment: 'AlignVCenter';
+    min-height:20px;
+    }
+    
+    QDialog#OptionsDialog QWidget#tabDisplay QValueComboBox {
+    margin-top:0px;
+    margin-bottom:0px;
+    }
+    
+    QDialog#OptionsDialog QLabel#label_3 { /* Translations Missing? Label */
+    qproperty-alignment: 'AlignVCenter | AlignCenter';
+    color:#818181;
+    padding-bottom:8px;
+    }
+    
+    QDialog#OptionsDialog QCheckBox {
+    min-height:20px;
+    }
+    
+    QDialog#OptionsDialog QCheckBox#displayAddresses {
+    min-height:33px;
+    }
+    
+    QDialog#OptionsDialog QLabel#labelStakeSplitThresholdText {
+    font-size:16px;
+    }
+    
+    /**************************** TOOLS MENU ************************************************/
+    
+    QDialog#RPCConsole QWidget#tab_info QLabel#label_11, QDialog#RPCConsole QWidget#tab_info QLabel#label_10 { /* Margin between Network and Block Chain headers */
+    qproperty-alignment: 'AlignBottom';
+    min-height:25px;
+    min-width:180px;
+    }
+    
+    QDialog#RPCConsole QWidget#tab_peers QLabel#peerHeading { /* Peers Info Header */
+    color:#304530;
+    }
+    
+    QDialog#RPCConsole QTableView#peerWidget::item { /* Peers Table Items */
+    color:#333;
+    }
+    
+    QDialog#RPCConsole QPushButton#openDebugLogfileButton {
+    max-width:60px;
+    }
+    
+    QDialog#RPCConsole QTextEdit#messagesWidget { /* Console Messages Window */
+    border:0;
+    background-color:#fcfcfc;
+    color:#333;
+    }
+    
+    QDialog#RPCConsole QLineEdit#lineEdit { /* Console Input */
+    margin-right:5px;
+    }
+    
+    QDialog#RPCConsole QPushButton#clearButton { /* Console Clear Button */
+    background-color:transparent;
+    padding-left:10px;
+    padding-right:10px;
+    }
+    
+    QDialog#RPCConsole .QGroupBox #line { /* Network In Line */
+    background-color:#4c7b4c;
+    }
+    
+    QDialog#RPCConsole .QGroupBox #line_2 { /* Network Out Line */
+    background:#fff;
+    }
+    
+    /**************************** HELP MENU *************************************************/
+    
+    /* Command Line Options Dialog */
+    QDialog#HelpMessageDialog QScrollArea * {
+    background-color:#fff;
+    }
+    
+    QDialog#HelpMessageDialog QScrollBar:vertical, QDialog#HelpMessageDialog QScrollBar:horizontal {
+    border:0;
+    }
+    
+    /* About Pivx Dialog */
+    QDialog#AboutDialog QLabel#label, QDialog#AboutDialog QLabel#copyrightLabel, QDialog#AboutDialog QLabel#label_2 { /* About Pivx Contents */
+    margin-left:10px;
+    }
+    
+    QDialog#AboutDialog QLabel#label_2 { /* Margin for About Pivx text */
+    margin-right:10px;
+    }
+    
+    /* Edit Address Dialog */
+    QDialog#EditAddressDialog QLabel {
+    qproperty-alignment: 'AlignVCenter | AlignRight';
+    min-height:27px;
+    font-weight:normal;
+    padding-right:5px;
+    }
+    
+    /* Header design for ALL tabs/pages *****************************************************/
+    /* Horizontal lines */
+    QFrame[frameShape="4"] { /* QFrame::HLine == 0x0004 */
+    border:1px solid #004d00;
+    }
+    
+    /* Headers */
+    QLabel#labelOverviewHeaderLeft {
+    font-weight:bold;
+    font-size:20px;
+    background-color:#ffffff;
+    }
+    
+    QLabel#labelOverviewHeaderRight {
+    qproperty-alignment: 'AlignVCenter | AlignRight';
+    background-image: url(':/images/pivx_logo_horizontal');
+    background-repeat: no-repeat;
+    }
+    
+    QWidget .QFrame#frame_Header { /* Header with Page-Title and PIVX-image */
+    min-width:400px;
+    background-color:#ffffff;
+    }
+    
+    QWidget .QFrame#frame_BG { /* Background */
+    min-width:400px;
+    background-color:#f8f6f6;
+    }
+    
+    /**************************** OVERVIEW SCREEN *******************************************/
+    
+    QWidget .QFrame#frame_Space { /* Space between Header and Content */
+    min-width:400px;
+    background-color:#f8f6f6;
+    }
+    
+    QWidget .QFrame#frame_Content { /* Actual Content */
+    min-width:400px;
+    background-color:#f8f6f6;
+    }
+    
+    QWidget .QFrame#frame_Balances { /* Upper left side */
+    min-width:400px;
+    background-color:#ffffff;
+    }
+    
+    QWidget .QFrame#frame_ZerocoinBalances { /* Lower left side */
+    min-width:400px;
+    background-color:#ffffff;
+    }
+    
+    QWidget .QFrame#frame_CombinedBalances { /* Lower left side */
+    min-width:400px;
+    background-color:#ffffff;
+    }
+    
+    QWidget .QFrame#frame_RecentTransactions { /* Right side */
+    min-width:400px;
+    background-color:#ffffff;
+    }
+    
+    QWidget .QFrame#frame_Balances > .QLabel {
+    min-width:190px;
+    font-weight:normal;
+    /* min-height:30px; */
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#label_5 { /* PIV Balances Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    background-color:transparent;
+    color:#304530;
+    font-weight:bold;
+    font-size:14px;
+    margin-right:5px;
+    padding-right:5px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelWalletStatus { /* Wallet Sync Status */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    margin-left:3px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelSpendable { /* Spendable Header */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    margin-left:18px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelWatchonly { /* Watch-only Header */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    margin-left:16px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelBalanceText { /* Available Balance Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelBalance { /* Available Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    font-weight:bold;
+    color:#4c7b4c;
+    margin-left:0px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelWatchAvailable { /* Watch-only Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    margin-left:16px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelPendingText { /* Pending Balance Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelUnconfirmed { /* Pending Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    font-weight:bold;
+    color:#4c7b4c;
+    margin-left:0px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelWatchPending { /* Watch-only Pending Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    margin-left:16px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelImmatureText { /* Immature Balance Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelImmature { /* Immature Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    font-weight:bold;
+    color:#4c7b4c;
+    margin-left:0px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelWatchImmature { /* Watch-only Immature Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    margin-left:16px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelTotalText { /* Total Balance Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelTotal { /* Total Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    font-weight:bold;
+    color:#4c7b4c;
+    margin-left:0px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelWatchTotal { /* Watch-only Total Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    margin-left:16px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelLockedBalanceText { /* Available zPIV Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelLockedBalance { /* Available zPIV Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    font-weight:bold;
+    color:#4c7b4c;
+    margin-left:0px;
+    }
+    
+    QWidget .QFrame#frame_Balances .QLabel#labelWatchLocked { /* Available zPIV Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    margin-left:16px;
+    }
+    
+    /* Zerocoin additions start here ***********************************************/
+    
+    QWidget .QFrame#frame_ZerocoinBalances .QLabel#label_5z_3 { /* Zerocoin Balance Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    background-color:transparent;
+    color:#304530;
+    font-weight:bold;
+    font-size:14px;
+    margin-right:5px;
+    padding-right:5px;
+    }
+    
+    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceText { /* Available zPIV Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalance { /* Available zPIV Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    font-weight:bold;
+    color:#4c7b4c;
+    margin-left:0px;
+    }
+    
+    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceUnconfirmedText { /* Unconfirmed zPIV Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceUnconfirmed { /* Unconfirmed zPIV Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    font-weight:bold;
+    color:#4c7b4c;
+    margin-left:0px;
+    }
+    
+    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceMatureText { /* Mature zPIV Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceMature { /* Mature zPIV Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    font-weight:bold;
+    color:#4c7b4c;
+    margin-left:0px;
+    }
+    
+    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceImmatureText { /* Immature zPIV Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceImmature { /* Immature zPIV Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    font-weight:bold;
+    color:#4c7b4c;
+    margin-left:0px;
+    }
+    
+    QWidget .QFrame#frame_CombinedBalances .QLabel#label_5z { /* Combined Balance Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    background-color:transparent;
+    color:#304530;
+    font-weight:bold;
+    font-size:14px;
+    margin-right:5px;
+    padding-right:5px;
+    }
+    
+    QWidget .QFrame#frame_CombinedBalances .QLabel#labelBalanceTextz { /* Available PIV Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_CombinedBalances .QLabel#labelBalancez { /* Available PIV Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:26px;
+    font-weight:normal;
+    color:#004d00;
+    }
+    
+    QWidget .QFrame#frame_CombinedBalances .QLabel#labelzBalanceTextz { /* Available zPIV Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_CombinedBalances .QLabel#labelzBalancez { /* Available zPIV Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:12px;
+    font-weight:bold;
+    color:#4c7b4c;
+    margin-left:0px;
+    }
+    
+    QWidget .QFrame#frame_CombinedBalances .QLabel#labelTotalTextz { /* Available total Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    color:#004d00;
+    margin-right:5px;
+    padding-right:5px;
+    font-weight:bold;
+    font-size:12px;
+    }
+    
+    QWidget .QFrame#frame_CombinedBalances .QLabel#labelTotalz { /* Available total Balance */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    font-size:26px;
+    font-weight:normal;
+    color:#004d00;
+    }
+    
+    /**************************** RECENT TRANSACTIONS ***************************************/
+    
+    QWidget .QFrame#frame_RecentTransactions { /* Transactions Widget */
+    min-width:410px;
+    min-height:100px;
+    margin-left:0;
+    margin-top:0;
+    }
+    
+    QWidget .QFrame#frame_RecentTransactions .QLabel#label_4 { /* Recent Transactions Label */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:180px;
+    background-color:transparent;
+    color:#304530;
+    font-weight:bold;
+    font-size:14px;
+    margin-right:5px;
+    padding-right:5px;
+    }
+    
+    QWidget .QFrame#frame_RecentTransactions .QLabel#labelTransactionsStatus { /* Recent Transactions Sync Status */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    margin-left:3px;
+    }
+    
+    QWidget .QFrame#frame_RecentTransactions QListView { /* Transaction List */
+    font-weight:normal;
+    font-size:12px;
+    max-width:369px;
+    margin-top:12px;
+    margin-left:0px; /* CSS Voodoo - set to -66px to hide default transaction icons */
+    }
+    
+    /**************************** SEND DIALOG ***********************************************/
+    
+    QDialog#SendCoinsDialog {
+    background-color:#fff;
+    }
+    
+    QDialog#SendCoinsDialog .QFrame#frameCoinControl { /* Coin Control Section */
+    background-color:#ffffff;
+    }
+    
+    QDialog#SendCoinsDialog .QFrame#frameFee { /* Coin Control Section */
+    background-color:#ffffff;
+    }
+    
+    QDialog#SendCoinsDialog .QFrame#frame_Send { /* Coin Control Section */
+    background-color:#ffffff;
+    margin-bottom:6px;
+    }
+    
+    QDialog#SendCoinsDialog .QFrame#frameCoinControl { /* Coin Control Section */
+    /* background-color:#ffff00; */
+    }
+    
+    QDialog#SendCoinsDialog .QFrame#frameCoinControl > .QLabel { /* Default Font Color and  Size */
+    font-weight:normal;
+    }
+    
+    QDialog#SendCoinsDialog .QFrame#frameCoinControl .QPushButton#pushButtonCoinControl { /* Coin Control Inputs Button */
+    padding-left:10px;
+    padding-right:10px;
+    min-height:25px;
+    }
+    
+    QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlFeatures { /* Coin Control Header */
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
+    min-width:160px;
+    background-color:transparent;
+    color:#304530;
+    font-weight:bold;
+    font-size:14px;
+    margin-right:5px;
+    padding-right:5px;
+    }
+    
+    QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl { /* Coin Control Inputs */
+    }
+    
+    QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl > .QLabel { /* Coin Control Inputs Labels */
+    padding:2px;
+    }
+    
+    /* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QCheckBox#checkBoxCoinControlChange { /* Custom Change Label */
+    /* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QValidatedLineEdit#lineEditCoinControlChange { /* Custom Change Address */
+    /* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QValidatedLineEdit#lineEditCoinControlChange:!focus { /* Custom Change Address */
+    /* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLineEdit#splitBlockLineEdit { */
+    /* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLineEdit#splitBlockLineEdit:!focus { /* TX Splitter */
+    
+    QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlChangeLabel { /* Custom Change Address Validation Label */
+    font-weight:normal;
+    }
+    
+    QDialog#SendCoinsDialog .QScrollArea#scrollArea .QWidget#scrollAreaWidgetContents { /* Send To Widget */
+    background-color:#ffffff;
+    }
+    
+    
+    
+    QDialog#SendCoinsDialog .QCheckBox#checkUseObfuscation { /* Obfuscation Checkbox */
+    color:#616161;
+    font-weight:bold;
+    /*background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));*/
+    border-radius:5px;
+    padding-top:20px;
+    padding-bottom:18px;
+    }
+    
+    QDialog#SendCoinsDialog .QCheckBox#checkSwiftTX { /* SwiftTX Checkbox */
+    color:#616161;
+    font-weight:bold;
+    /*background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));*/
+    border-radius:5px;
+    padding-top:20px;
+    padding-bottom:18px;
+    margin-left:10px;
+    margin-right:20px;
+    }
+    
+    /* This QLabel uses name = "label" which conflicts with Address Book -> New Address */
+    /* To maximize backwards compatibility this formatting has been removed */
+    
+    QDialog#SendCoinsDialog QLabel#label {
+    min-height:27px;
+    }
+    
+    QDialog#SendCoinsDialog QLabel#labelBalance {
+    margin-left:0px;
+    padding-left:0px;
+    color:#333333;
+    min-height:27px;
+    }
+    
+    /**************************** SEND COINS ENTRY ******************************************/
+    
+    QStackedWidget#SendCoinsEntry .QFrame#SendCoins > .QLabel { /* Send Coin Entry Labels */
+    min-width:10px;
+    font-weight:bold;
+    min-height:25px;
+    margin-right:5px;
+    padding-right:5px;
+    }
+    
+    /* QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo { /* Pay To Input Field */
+    /* QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo:!focus { /* Pay To Input Field */
+    /* QStackedWidget#SendCoinsEntry .QToolButton { /* Pay To Custom ToolButton */
+    /* QStackedWidget#SendCoinsEntry .QToolButton:hover { /* Pay To Custom ToolButton */
+    /* QStackedWidget#SendCoinsEntry .QToolButton:focus { /* Pay To Custom ToolButton */
+    /* QStackedWidget#SendCoinsEntry .QToolButton:pressed { /* Pay To Custom ToolButton */
+    /* QStackedWidget#SendCoinsEntry .QToolButton#addressBookButton { /* Address Book Button */
+    /* QStackedWidget#SendCoinsEntry .QToolButton#pasteButton { */
+    /* QStackedWidget#SendCoinsEntry .QToolButton#deleteButton { */
+    /* QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel { /* Pay To Input Field */
+    /* QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel:!focus { /* Pay To Input Field */
+    
+    /**************************** COIN CONTROL POPUP ****************************************/
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlQuantityText { /* Coin Control Quantity Label */
+    min-height:30px;
+    padding-left:15px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlQuantity { /* Coin Control Quantity */
+    min-height:30px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlBytesText { /* Coin Control Bytes Label */
+    padding-left:15px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlBytes { /* Coin Control Bytes */
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlAmountText { /* Coin Control Amount Label */
+    min-height:30px;
+    padding-left:15px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlAmount { /* Coin Control Amount */
+    min-height:30px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlPriorityText { /* Coin Control Priority Label */
+    padding-left:15px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlPriority { /* Coin Control Priority */
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlFeeText { /* Coin Control Fee Label */
+    min-height:30px;
+    padding-left:15px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlFee { /* Coin Control Fee */
+    min-height:30px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlLowOutputText { /* Coin Control Low Output Label */
+    padding-left:15px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlLowOutput { /* Coin Control Low Output */
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlAfterFeeText { /* Coin Control After Fee Label */
+    min-height:30px;
+    padding-left:15px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlAfterFee { /* Coin Control After Fee */
+    min-height:30px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlChangeText { /* Coin Control Change Label */
+    padding-left:15px;
+    }
+    
+    QDialog#CoinControlDialog .QLabel#labelCoinControlChange { /* Coin Control Change */
+    
+    }
+    
+    QDialog#CoinControlDialog .QFrame#frame .QPushButton#pushButtonSelectAll { /* (un)select all button */
+    padding-left:10px;
+    padding-right:10px;
+    min-height:25px;
+    }
+    
+    QDialog#CoinControlDialog .QFrame#frame .QPushButton#pushButtonToggleLock { /* Toggle lock state button */
+    padding-left:10px;
+    padding-right:10px;
+    min-height:25px;
+    }
+    
+    QDialog#CoinControlDialog .QDialogButtonBox#buttonBox QPushButton { /* Coin Control 'OK' button */
+    }
+    
+    QDialog#CoinControlDialog .QFrame#frame .QRadioButton#radioTreeMode { /* Coin Control Tree Mode Selector */
+    color:#818181;
+    background-color:transparent;
+    }
+    
+    QDialog#CoinControlDialog .QFrame#frame .QRadioButton#radioListMode { /* Coin Control List Mode Selector */
+    color:#818181;
+    background-color:transparent;
+    }
+    
+    QDialog#CoinControlDialog QHeaderView::section:first { /* Bug Fix: the number "1" displays in this table for some reason... */
+    color:transparent;
+    }
+    
+    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget { /* Coin Control Widget Container */
+    outline:0;
+    background-color:#ffffff;
+    border:1px solid #333;
+    }
+    
+    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {
+    }
+    
+    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:selected { /* Coin Control Item (selected) */
+    background-color:#4c7b4c;
+    color:#fff;
+    }
+    
+    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:checked { /* Coin Control Item (checked) */
+    background-color:#f7f7f7;
+    color:#fff;
+    }
+    
+    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:selected { /* Coin Control Branch Icon */
+    background-image: url(':/images/qtreeview_selected');
+    background-repeat:no-repeat;
+    background-position:center;
+    background-color:#f7f7f7;
+    color:#333;
+    }
+    
+    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:checked { /* Coin Control Branch Icon */
+    background-image: url(':/images/qtreeview_selected');
+    background-repeat:no-repeat;
+    background-position:center;
+    background-color:#f7f7f7;
+    color:#333;
+    }
+    
+    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::seperator {
+    
+    }
+    
+    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::indicator { /* Coin Control Widget Checkbox */
+    
+    }
+    
+    QDialog#ZPivControlDialog .QTreeWidget#treeWidget { /* zPIV Control Widget Container */
+    outline:0;
+    background-color:#ffffff;
+    border:1px solid #333;
+    }
+    
+    /**************************** RECEIVE COINS *********************************************/
+    
+    QWidget#ReceiveCoinsDialog {
+    background-color:#fff;
+    }
+    
+    QWidget#ReceiveCoinsDialog .QFrame#frame {
+    background-color:#ffffff;
+    }
+    
+    QWidget#ReceiveCoinsDialog .QFrame#frame2 {
+    background-color:#ffffff;
+    }
+    
+    QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLabel { /* Receive Coin Labels */
+    min-width:10px;
+    font-weight:bold;
+    min-height:25px;
+    margin-right:5px;
+    padding-right:5px;
+    }
+    
+    /* QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLineEdit { /* Receive Coin LineEdits */
+    /* QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLineEdit:!focus { /* Receive Coin LineEdits */
+    
+    QWidget#ReceiveCoinsDialog .QFrame#frame QPushButton { /* Clear Button */
+    padding-left:10px;
+    padding-right:10px;
+    }
+    
+    QWidget#ReceiveCoinsDialog .QFrame#frame QPushButton:pressed {
+    border:1px solid #9e9e9e;
+    }
+    
+    QWidget#ReceiveCoinsDialog .QFrame#frame2 QPushButton { /* Clear Button */
+    padding-left:10px;
+    padding-right:10px;
+    }
+    
+    QWidget#ReceiveCoinsDialog .QFrame#frame2 QPushButton:pressed {
+    border:1px solid #9e9e9e;
+    }
+    
+    QWidget#ReceiveCoinsDialog .QFrame#frame .QLabel#label_6 { /* Requested Payments History Label */
+    color:#304530;
+    font-weight:bold;
+    font-size:14px;
+    }
+    
+    /**************************** RECEIVE COINS DIALOG **************************************/
+    
+    QDialog#ReceiveRequestDialog QTextEdit { /* Contents of Receive Coin Dialog */
+    border:1px solid #d7d7d7;
+    }
+    
+    /**************************** TRANSACTIONS PAGE *****************************************/
+    
+    TransactionView QLineEdit { /* Address Filter */
+    margin-bottom:2px;
+    margin-right:1px;
+    min-width:111px;
+    text-align:center;
+    }
+    
+    TransactionView QComboBox {
+    margin-bottom:1px;
+    margin-right:1px;
+    }
+    
+    QLabel#transactionSumLabel { /* Example of setObjectName for widgets without name */
+    color:#333333;
+    font-weight:bold;
+    }
+    
+    QLabel#transactionSum { /* Example of setObjectName for widgets without name */
+    color:#333333;
+    }
+    
+    /**************************** TRANSACTION DETAILS DIALOG ********************************/
+    
+    QDialog#TransactionDescDialog QTextEdit { /* Contents of Receive Coin Dialog */
+    border:1px solid #d7d7d7;
+    }
+    
+    /**************************** PRIVACY PAGE *****************************************/
+    /* QDialog#PrivacyDialog */
+    /* QWidget#PrivacyDialog */
+    
+    QWidget#PrivacyDialog .QFrame[frameShape="4"] { /* QFrame::HLine == 0x0004 */
+    border:1px solid #004d00;
+    }
+    
+    QWidget#PrivacyDialog .QFrame#frame_Content {
+    background-color:#f8f6f6;
+    }
+    
+    QWidget#PrivacyDialog .QFrame#verticalFrameLeft {
+    background-color:#ffffff;
+    }
+    
+    QWidget#PrivacyDialog .QFrame#verticalFrameRight {
+    background-color:#ffffff;
+    }
+    
+    QWidget#PrivacyDialog .QToolButton {
+    margin:2px;
+    min-height: 24px;
+    min-width: 24px;
+    }
+    
+    /**************************** MASTERNODE LIST *******************************************/
+    QWidget#MasternodeList .QFrame#frameList {
+    background-color:#ffffff;
+    }
+    
+    
+    /********************************* CALENDAR WIDGET **************************************/
+    
+    QCalendarView {
+    border:1px solid #333;
+    }
+    
+    QCalendarWidget QWidget#qt_calendar_navigationbar { /* Calendar widget navigation bar */
+    background-color:#4c7b4c;
+    font-weight:bold;
+    }
+    
+    QCalendarWidget QAbstractItemView { /* Calendar widget days */
+    alternate-background-color:#dedbe5;
+    background-color:#fff;
+    }
+    
+    QCalendarWidget QAbstractItemView:enabled { /* Calendar widget weekdays in month */
+    color:#333;
+    }
+    
+    QCalendarWidget QAbstractItemView:disabled { /* Calendar widget days not in month */
+    color:#818181;
+    }
+    
+    QWidget#GovernancePage .QFrame#frame_Content {
+        background-color:#ffffff;
+    }
+    
+    QWidget#GovernancePage .ProposalFrame {
+        border-radius:5px;
+        margin:2px;
+        max-height:250px;
+    }
+    
+    QWidget#GovernancePage .ProposalFrame#proposalFrame {
+        background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #7ac77a, stop: 1 #98f698);
+        border:1px solid #98f698;
+    }
+    
+    QWidget#GovernancePage .ProposalFrame#proposalFramePassing {
+        background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #00cc00, stop: 1 #00ef00);
+        border:1px solid #00ef00;
+    }
+    
+    QWidget#GovernancePage .ProposalFrame > QLabel#strProposalName, QLabel#strMonthlyPayout, QLabel#strRemainingPaymentCount {
+        font-size:18pt;
+    }
+    
+    QWidget#GovernancePage .ProposalFrame > QLabel#strProposalURL {
+        font-size:14pt;
+    }
+    
+    QWidget#GovernancePage .QScrollArea, .QWidget#scrollAreaWidgetContents {
+        background-color:#fff;
+    }
+    
+    QWidget#GovernancePage .QGridLayout#proposalGrid {
+        margin-right:35px!important;
+        padding-right:35px!important;
+    }
+    

--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -22,568 +22,602 @@
 /****************************************************************************************/
 
 WalletFrame {
-    background-color:#ffffff;
-    border-top:0px solid #000;
-    margin:0;
-    padding:0;
-    }
-    
-    QStatusBar {
-    background-color:#ffffff;
-    }
-    
-    .QFrame {
-    background-color:transparent;
-    border:0px solid #fff;
-    }
-    
-    QMenuBar {
-    background-color:#fff;
-    }
-    
-    QMenuBar::item {
-    background-color:#fff;
-    color:#333;
-    }
-    
-    QMenuBar::item:selected {
-    background-color:#f8f6f6;
-    }
-    
-    QMenu {
-    background-color:#f8f6f6;
-    }
-    
-    QMenu::item {
-    color:#333;
-    }
-    
-    QMenu::item:selected {
-    background-color:#f2f0f0;
-    color:#333;
-    }
-    
-    QToolBar {
+    background-color: #ffffff;
+    border-top: 0px solid #000;
+    margin: 0;
+    padding: 0;
+}
+
+QStatusBar {
+    background-color: #ffffff;
+}
+
+.QFrame {
+    background-color: transparent;
+    border: 0px solid #fff;
+}
+
+QMenuBar {
+    background-color: #fff;
+}
+
+QMenuBar::item {
+    background-color: #fff;
+    color: #333;
+}
+
+QMenuBar::item:selected {
+    background-color: #f8f6f6;
+}
+
+QMenu {
+    background-color: #f8f6f6;
+}
+
+QMenu::item {
+    color: #333;
+}
+
+QMenu::item:selected {
+    background-color: #f2f0f0;
+    color: #333;
+}
+
+QToolBar {
     background-color: qlineargradient(y1:0, y2: 1, stop: 0 #004d00, stop: 0.75 #004d00, stop: 0.99 #ffffff, stop: 1 #ffffff);
-    border:0px solid #333;
-    padding:1;
-    margin:0;
+    border: 0px solid #333;
+    padding: 1;
+    margin: 0;
     width: 70px;
-    }
-    
-    QToolBar > QToolButton {
+}
+
+QToolBar>QToolButton {
     Alignment: left;
     background-color: #004d00;
-    selection-background-color:transparent;
-    border:0.5px solid #888;
+    selection-background-color: transparent;
+    border: 0.5px solid #888;
     border-left: 0px;
     border-right: 0px;
     border-top: 0px;
-    min-height:2.5em;
+    min-height: 2.5em;
     padding: 0em 0em;
     font-size: 11px;
-    color:#aaa;
+    color: #aaa;
     width: 80px;
     height: 60px;
-    }
-    
-    QToolBar > QToolButton:checked {
+}
+
+QToolBar>QToolButton:checked {
     background-color: qlineargradient(x1:0, x2: 1, stop: 0 #ffffff, stop: 0.07 #ffffff, stop: 0.0701 #004d00, stop: 1 #004d00);
-    color:#fff;
-    }
-    
-    /* QToolBar > QToolButton:hover:!selected { */
-    QToolBar > QToolButton:hover {
+    color: #fff;
+}
+
+/* QToolBar > QToolButton:hover:!selected { */
+
+QToolBar>QToolButton:hover {
     background-color: qlineargradient(x1:0, x2: 1, stop: 0 #ffffff, stop: 0.07 #ffffff, stop: 0.0701 #004d00, stop: 1 #004d00);
-    color:#fff;
-    }
-    
-    QToolBar > QToolButton#ToolbarSpacer:hover:!selected {
-    background-color: #004d00; /* Do not highlight placeholder on hover */
-    }
-    
-    QToolBar > QToolButton:pressed {
+    color: #fff;
+}
+
+QToolBar>QToolButton#ToolbarSpacer:hover:!selected {
+    background-color: #004d00;
+    /* Do not highlight placeholder on hover */
+}
+
+QToolBar>QToolButton:pressed {
     background-color: qlineargradient(x1:0, x2: 1, stop: 0 #00a300, stop: 0.07 #00a300, stop: 0.0701 #004d00, stop: 1 #004d00);
-    color:#fff;
-    }
-    
-    QMessageBox {
-    background-color:#fff;
-    }
-    
-    QProgressBar {
+    color: #fff;
+}
+
+QMessageBox {
+    background-color: #fff;
+}
+
+QProgressBar {
     color: #AAAAAA;
-    border:0px solid grey;
-    border-radius:5px;
-    background-color:transparent;
-    padding-left:0px;
-    padding-right:0px;
-    }
-    
-    QProgressBar::chunk {
-    background-color:#4c7b4c;
+    border: 0px solid grey;
+    border-radius: 5px;
+    background-color: transparent;
+    padding-left: 0px;
+    padding-right: 0px;
+}
+
+QProgressBar::chunk {
+    background-color: #4c7b4c;
     width: 20px;
-    }
-    
-    QLabel#progressBarLabel {
-    background-color:transparent;
+}
+
+QLabel#progressBarLabel {
+    background-color: transparent;
     color: #304530;
-    padding-left:5px;
-    padding-right:5px;
-    }
-    
-    QTabWidget {
-    background-color:#f2f2f2;
-    }
-    
-    QTabWidget::pane {
-    background-color:#f2f2f2;
-    border:1px solid #c2c2c2;
-    }
-    
-    QTabBar {
-    background-color:#f2f2f2;
-    color:#333;
-    }
-    
-    QTabBar::tab:hover:!selected {
-    background-color:#dedbe5;
-    }
-    
-    QWidget {
-    selection-background-color:#4c7b4c; /* Object highlight color */
-    selection-color:#fff;
-    outline:0; /* Remove Annoying Focus Rectangle */
-    }
-    
-    QGroupBox {
-    background-color:#fcfcfc;
-    color:#333;
-    }
-    
-    QToolTip {
-    background-color:#dedbe5;
-    color:#333;
-    }
-    
-    /****************************************************************************************/
-    
-    QLabel { /* Base Text Size & Color */
-    font-size:12px;
-    color:#333333;
-    }
-    
-    .QRadioButton { /* Radio Button Labels */
-    color:#333333;
-    }
-    
-    .QCheckBox { /* Checkbox Labels */
-    color:#333333;
-    }
-    
-    .QCheckBox:hover {
-    }
-    
-    .QValidatedLineEdit, .QLineEdit, .QTextEdit { /* Text Entry Fields */
-    font-size:12px;
-    min-height:25px;
-    outline:0;
-    padding:3px;
-    border:0px;
-    color:#333;
-    background-color:#f2f2f2;
-    }
-    
-    .QValidatedLineEdit:!focus {
-    color:#4c7b4c;
-    background-color:#e7e7e7;
-    }
-    
-    .QLineEdit:!focus {
-    color:#4c7b4c;
-    background-color:#e7e7e7;
-    }
-    
-    .QTextEdit:!focus {
-    color:#4c7b4c;
-    background-color:#e7e7e7;
-    }
-    
-    /* .QValidatedLineEdit:checked, .QLineEdit:checked */
-    
-    .QValidatedLineEdit:disabled, .QLineEdit:disabled, .QTextEdit:disabled {
+    padding-left: 5px;
+    padding-right: 5px;
+}
+
+QTabWidget {
+    background-color: #f2f2f2;
+}
+
+QTabWidget::pane {
+    background-color: #f2f2f2;
+    border: 1px solid #c2c2c2;
+}
+
+QTabBar {
+    background-color: #f2f2f2;
+    color: #333;
+}
+
+QTabBar::tab:hover:!selected {
+    background-color: #dedbe5;
+}
+
+QWidget {
+    selection-background-color: #4c7b4c;
+    /* Object highlight color */
+    selection-color: #fff;
+    outline: 0;
+    /* Remove Annoying Focus Rectangle */
+}
+
+QGroupBox {
+    background-color: #fcfcfc;
+    color: #333;
+}
+
+QToolTip {
+    background-color: #dedbe5;
+    color: #333;
+}
+
+/****************************************************************************************/
+
+QLabel {
+    /* Base Text Size & Color */
+    font-size: 12px;
+    color: #333333;
+}
+
+.QRadioButton {
+    /* Radio Button Labels */
+    color: #333333;
+}
+
+.QCheckBox {
+    /* Checkbox Labels */
+    color: #333333;
+}
+
+.QCheckBox:hover {}
+
+.QValidatedLineEdit, .QLineEdit, .QTextEdit {
+    /* Text Entry Fields */
+    font-size: 12px;
+    min-height: 25px;
+    outline: 0;
+    padding: 3px;
+    border: 0px;
+    color: #333;
+    background-color: #f2f2f2;
+}
+
+.QValidatedLineEdit:!focus {
     color: #4c7b4c;
-    background-color:#f2f2f2;
-    }
-    
-    .QPlainTextEdit {
-    background-color:#f2f2f2;
-    }
-    
-    /***************************** Global Qt Objects ***********************************************************/
-    
-    QPushButton { /* Global Button Style */
+    background-color: #e7e7e7;
+}
+
+.QLineEdit:!focus {
+    color: #4c7b4c;
+    background-color: #e7e7e7;
+}
+
+.QTextEdit:!focus {
+    color: #4c7b4c;
+    background-color: #e7e7e7;
+}
+
+/* .QValidatedLineEdit:checked, .QLineEdit:checked */
+
+.QValidatedLineEdit:disabled, .QLineEdit:disabled, .QTextEdit:disabled {
+    color: #4c7b4c;
+    background-color: #f2f2f2;
+}
+
+.QPlainTextEdit {
+    background-color: #f2f2f2;
+}
+
+/***************************** Global Qt Objects ***********************************************************/
+
+QPushButton {
+    /* Global Button Style */
     background-color: #4c7b4c;
     border-width: 1px;
     border-style: outset;
     border-color: #304530;
     border-radius: 2px;
-    color:#ffffff;
-    font-size:12px;
-    font-weight:bold;
-    padding-left:25px;
-    padding-right:25px;
-    padding-top:1px;
-    padding-bottom:1px;
+    color: #ffffff;
+    font-size: 12px;
+    font-weight: bold;
+    padding-left: 25px;
+    padding-right: 25px;
+    padding-top: 1px;
+    padding-bottom: 1px;
     height: 26px;
     margin: 2px;
-    }
-    
-    QPushButton:hover {
+}
+
+QPushButton:hover {
     background-color: qlineargradient(y1:0, y2: 1, stop: 0 #ffffff, stop: 0.1 #ffffff, stop: 0.101 #5ca35c, stop: 0.9 #5ca35c, stop: 0.901 #ffffff, stop: 1 #ffffff);
-    }
-    
-    QPushButton:focus {
+}
+
+QPushButton:focus {
     /* border:none; */
     /* outline:none; */
-    }
-    
-    QPushButton:pressed {
+}
+
+QPushButton:pressed {
     background-color: #4c7b4c;
-    border:1px solid #000000;
+    border: 1px solid #000000;
     background-color: qlineargradient(y1:0, y2: 1, stop: 0 #00ff00, stop: 0.1 #00ff00, stop: 0.101 #5ca35c, stop: 0.9 #5ca35c, stop: 0.901 #00ff00, stop: 1 #00ff00);
-    }
-    
-    /* Special handling for statusbar-icons (which are partly QPushButtons) */
-    QPushButton#labelEncryptionIcon, QPushButton#labelConnectionsIcon, QPushButton#labelAutoMintIcon {
+}
+
+/* Special handling for statusbar-icons (which are partly QPushButtons) */
+
+QPushButton#labelEncryptionIcon, QPushButton#labelConnectionsIcon, QPushButton#labelAutoMintIcon {
     border: 0px;
-    padding-left:0px;
-    padding-right:0px;
-    padding-top:0px;
-    padding-bottom:0px;
+    padding-left: 0px;
+    padding-right: 0px;
+    padding-top: 0px;
+    padding-bottom: 0px;
     margin: 0px;
-    }
-    
-    /* QSpinBox::up-arrow:hover */
-    /* QSpinBox::down-arrow:hover */
-    
-    QSpinBox::up-button:hover {
+}
+
+/* QSpinBox::up-arrow:hover */
+
+/* QSpinBox::down-arrow:hover */
+
+QSpinBox::up-button:hover {
     background-color: #f2f2f2;
-    }
-    
-    QSpinBox::down-button:hover {
+}
+
+QSpinBox::down-button:hover {
     background-color: #f2f2f2;
-    }
-    
-    QComboBox { /* Dropdown Menus */
-    border:1px solid #4c7b4c;
+}
+
+QComboBox {
+    /* Dropdown Menus */
+    border: 1px solid #4c7b4c;
     padding: 3px 5px 3px 5px;
-    background:#fcfcfc;
-    min-height:25px;
-    color:#818181;
-    }
-    
-    QComboBox:checked {
-    background:#f2f2f2;
-    }
-    
-    QComboBox:editable {
-    background:#304530;
-    color:#616161;
-    border:0px solid transparent;
-    }
-    
-    QComboBox::drop-down {
-    width:25px;
-    border:0px;
-    }
-    
-    QComboBox::down-arrow {
+    background: #fcfcfc;
+    min-height: 25px;
+    color: #818181;
+}
+
+QComboBox:checked {
+    background: #f2f2f2;
+}
+
+QComboBox:editable {
+    background: #304530;
+    color: #616161;
+    border: 0px solid transparent;
+}
+
+QComboBox::drop-down {
+    width: 25px;
+    border: 0px;
+}
+
+QComboBox::down-arrow {
     border-image: url(':/images/downArrow') 0 0 0 0 stretch stretch;
-    }
-    
-    QComboBox QListView {
-    background:#fff;
-    border:1px solid #333;
-    padding-right:1px;
-    padding-left:1px;
-    color:#818181;
-    }
-    
-    QComboBox QAbstractItemView::item {
-    margin:4px;
-    }
-    
-    QComboBox::item {
-    color:#818181;
-    }
-    
-    QComboBox::item:alternate {
-    background:#fff;
-    }
-    
-    QComboBox::item:selected {
-    border:0px solid transparent;
-    background:#f2f2f2;
-    }
-    
-    QComboBox::indicator {
-    background-color:transparent;
-    selection-background-color:transparent;
-    color:transparent;
-    selection-color:transparent;
-    }
-    
-    QAbstractSpinBox {
+}
+
+QComboBox QListView {
+    background: #fff;
+    border: 1px solid #333;
+    padding-right: 1px;
+    padding-left: 1px;
+    color: #818181;
+}
+
+QComboBox QAbstractItemView::item {
+    margin: 4px;
+}
+
+QComboBox::item {
+    color: #818181;
+}
+
+QComboBox::item:alternate {
+    background: #fff;
+}
+
+QComboBox::item:selected {
+    border: 0px solid transparent;
+    background: #f2f2f2;
+}
+
+QComboBox::indicator {
+    background-color: transparent;
+    selection-background-color: transparent;
+    color: transparent;
+    selection-color: transparent;
+}
+
+QAbstractSpinBox {
     padding: 3px 5px 3px 5px;
-    background:#fcfcfc;
-    font-size:12px;
-    min-height:25px;
-    outline:0;
-    padding:3px;
-    border:0px;
-    color:#333;
-    background-color:#f2f2f2;
-    }
-    
-    QAbstractSpinBox:!focus {
-    color:#4c7b4c;
-    background-color:#e7e7e7;
-    }
-    
-    QAbstractSpinBox::up-button {
+    background: #fcfcfc;
+    font-size: 12px;
+    min-height: 25px;
+    outline: 0;
+    padding: 3px;
+    border: 0px;
+    color: #333;
+    background-color: #f2f2f2;
+}
+
+QAbstractSpinBox:!focus {
+    color: #4c7b4c;
+    background-color: #e7e7e7;
+}
+
+QAbstractSpinBox::up-button {
     subcontrol-origin: border;
     subcontrol-position: top right;
-    width:21px;
-    background:#e7e7e7; /* Remove this to get 3D rendered buttons */
-    padding-right:1px;
-    padding-left:5px;
-    padding-top:2px;
-    }
-    
-    QAbstractSpinBox::up-arrow {
-    image:url(':/images/upArrow_small');
-    }
-    
-    QAbstractSpinBox::down-button {
+    width: 21px;
+    background: #e7e7e7;
+    /* Remove this to get 3D rendered buttons */
+    padding-right: 1px;
+    padding-left: 5px;
+    padding-top: 2px;
+}
+
+QAbstractSpinBox::up-arrow {
+    image: url(':/images/upArrow_small');
+}
+
+QAbstractSpinBox::down-button {
     subcontrol-origin: border;
     subcontrol-position: bottom right;
-    width:21px;
-    background:#e7e7e7; /* Remove this to get 3D rendered buttons */
-    padding-right:1px;
-    padding-left:5px;
-    padding-bottom:2px;
-    }
-    
-    QAbstractSpinBox::down-arrow {
-    image:url(':/images/downArrow_small');
-    }
-    
-    QValueComboBox {
+    width: 21px;
+    background: #e7e7e7;
+    /* Remove this to get 3D rendered buttons */
+    padding-right: 1px;
+    padding-left: 5px;
+    padding-bottom: 2px;
+}
+
+QAbstractSpinBox::down-arrow {
+    image: url(':/images/downArrow_small');
+}
+
+QValueComboBox {
     padding: 3px 5px 3px 5px;
-    background:#fcfcfc;
-    font-size:12px;
-    min-height:25px;
-    outline:0;
-    padding:3px;
-    border:0px;
-    color:#333;
-    background-color:#f2f2f2;
-    }
-    
-    QValueComboBox:!focus {
-    color:#4c7b4c;
-    background-color:#e7e7e7;
-    }
-    
-    /****************************************************************************************/
-    
-    QHeaderView { /* Table Header */
-    background-color:transparent;
-    outline:0;
-    }
-    
-    QHeaderView::section { /* Table Header Sections */
-    qproperty-alignment:center;
+    background: #fcfcfc;
+    font-size: 12px;
+    min-height: 25px;
+    outline: 0;
+    padding: 3px;
+    border: 0px;
+    color: #333;
+    background-color: #f2f2f2;
+}
+
+QValueComboBox:!focus {
+    color: #4c7b4c;
+    background-color: #e7e7e7;
+}
+
+/****************************************************************************************/
+
+QHeaderView {
+    /* Table Header */
+    background-color: transparent;
+    outline: 0;
+}
+
+QHeaderView::section {
+    /* Table Header Sections */
+    qproperty-alignment: center;
     background-color: #4c7b4c;
-    color:#fff;
-    min-height:25px;
-    font-weight:bold;
-    font-size:11px;
-    border:0;
-    border-right:1px solid #fff;
-    padding-left:5px;
-    padding-right:5px;
-    padding-top:2px;
-    padding-bottom:2px;
-    }
-    
-    QHeaderView::down-arrow {
-        image: url(':/images/downArrow_small_white');
-    }
-    
-    QHeaderView::up-arrow {
-        image: url(':/images/upArrow_small_white');
-    }
-    
-    QHeaderView::section:last {
-    border-right:0;
-    }
-    
-    .QScrollArea {
-    background:transparent;
-    border:0;
-    }
-    
-    .QTableView { /* Table - has to be selected as a class otherwise it throws off QCalendarWidget */
-    background:transparent;
-    border:1px solid #333;
-    }
-    
-    QTableView::item { /* Table Item */
-    background-color:#fcfcfc;
-    font-size:12px;
-    }
-    
-    QTableView::item:selected { /* Table Item Selected */
-    background-color:#4c7b4c;
-    color:#fff;
-    }
-    
-    QTableWidget { /* Table Background */
+    color: #fff;
+    min-height: 25px;
+    font-weight: bold;
+    font-size: 11px;
+    border: 0;
+    border-right: 1px solid #fff;
+    padding-left: 5px;
+    padding-right: 5px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+}
+
+QHeaderView::down-arrow {
+    image: url(':/images/downArrow_small_white');
+}
+
+QHeaderView::up-arrow {
+    image: url(':/images/upArrow_small_white');
+}
+
+QHeaderView::section:last {
+    border-right: 0;
+}
+
+.QScrollArea {
+    background: transparent;
+    border: 0;
+}
+
+.QTableView {
+    /* Table - has to be selected as a class otherwise it throws off QCalendarWidget */
+    background: transparent;
+    border: 1px solid #333;
+}
+
+QTableView::item {
+    /* Table Item */
+    background-color: #fcfcfc;
+    font-size: 12px;
+}
+
+QTableView::item:selected {
+    /* Table Item Selected */
+    background-color: #4c7b4c;
+    color: #fff;
+}
+
+QTableWidget {
+    /* Table Background */
     background-color: #fcfcfc;
     alternate-background-color: yellow;
-    border:1px solid #333;
-    }
-    
-    QTableWidget:focus, QTableView, QTableView:focus { /* Remove focus outline */
-    outline:0;
-    background:transparent;
-    }
-    
-    QTreeWidget { /* Tree Background */
-    background-color:#fcfcfc;
-    alternate-background-color:#f2f2f2;
-    color:#333;
-    }
-    
-    QScrollBar { /* Scroll Bar */
-    
-    }
-    
-    QScrollBar:vertical { /* Vertical Scroll Bar Attributes */
-    border:0;
-    background:#4c7b4c;
-    width:18px;
-    margin:18px 0px 18px 0px;
-    }
-    
-    QScrollBar:horizontal { /* Horizontal Scroll Bar Attributes */
-    border:0;
-    background:#4c7b4c;
-    height:18px;
-    margin:0px 18px 0px 18px;
-    }
-    
-    QScrollBar::handle:vertical { /* Scroll Bar Slider - vertical */
-    background:#4c7b4c;
-    min-height:10px;
-    }
-    
-    QScrollBar::handle:vertical:pressed { /* Scroll Bar Slider - vertical */
-    background:#7ac77a;
-    min-height:10px;
-    }
-    
-    QScrollBar::handle:horizontal { /* Scroll Bar Slider - horizontal */
-    background:#4c7b4c;
-    min-width:10px;
-    }
-    
-    QScrollBar::handle:horizontal:pressed { /* Scroll Bar Slider - horizontal */
-    background:#7ac77a;
-    min-width:10px;
-    }
-    
-    QScrollBar::add-page, QScrollBar::sub-page { /* Scroll Bar Background */
-    background:#F8F6F6;
-    }
-    
-    QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical, QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal { /* Define Arrow Button Dimensions */
-    background-color:#F8F6F6;
+    border: 1px solid #333;
+}
+
+QTableWidget:focus, QTableView, QTableView:focus {
+    /* Remove focus outline */
+    outline: 0;
+    background: transparent;
+}
+
+QTreeWidget {
+    /* Tree Background */
+    background-color: #fcfcfc;
+    alternate-background-color: #f2f2f2;
+    color: #333;
+}
+
+QScrollBar {
+    /* Scroll Bar */
+}
+
+QScrollBar:vertical {
+    /* Vertical Scroll Bar Attributes */
+    border: 0;
+    background: #4c7b4c;
+    width: 18px;
+    margin: 18px 0px 18px 0px;
+}
+
+QScrollBar:horizontal {
+    /* Horizontal Scroll Bar Attributes */
+    border: 0;
+    background: #4c7b4c;
+    height: 18px;
+    margin: 0px 18px 0px 18px;
+}
+
+QScrollBar::handle:vertical {
+    /* Scroll Bar Slider - vertical */
+    background: #4c7b4c;
+    min-height: 10px;
+}
+
+QScrollBar::handle:vertical:pressed {
+    /* Scroll Bar Slider - vertical */
+    background: #7ac77a;
+    min-height: 10px;
+}
+
+QScrollBar::handle:horizontal {
+    /* Scroll Bar Slider - horizontal */
+    background: #4c7b4c;
+    min-width: 10px;
+}
+
+QScrollBar::handle:horizontal:pressed {
+    /* Scroll Bar Slider - horizontal */
+    background: #7ac77a;
+    min-width: 10px;
+}
+
+QScrollBar::add-page, QScrollBar::sub-page {
+    /* Scroll Bar Background */
+    background: #F8F6F6;
+}
+
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical, QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
+    /* Define Arrow Button Dimensions */
+    background-color: #F8F6F6;
     border: 1px solid #f2f0f0;
-    width:16px;
-    height:16px;
-    }
-    
-    QScrollBar::add-line:vertical:pressed, QScrollBar::sub-line:vertical:pressed, QScrollBar::add-line:horizontal:pressed, QScrollBar::sub-line:horizontal:pressed {
-    background-color:#e0e0e0;
-    }
-    
-    QScrollBar::sub-line:vertical { /* Vertical - top button position */
-    subcontrol-position:top;
+    width: 16px;
+    height: 16px;
+}
+
+QScrollBar::add-line:vertical:pressed, QScrollBar::sub-line:vertical:pressed, QScrollBar::add-line:horizontal:pressed, QScrollBar::sub-line:horizontal:pressed {
+    background-color: #e0e0e0;
+}
+
+QScrollBar::sub-line:vertical {
+    /* Vertical - top button position */
+    subcontrol-position: top;
     subcontrol-origin: margin;
-    }
-    
-    QScrollBar::add-line:vertical { /* Vertical - bottom button position */
-    subcontrol-position:bottom;
+}
+
+QScrollBar::add-line:vertical {
+    /* Vertical - bottom button position */
+    subcontrol-position: bottom;
     subcontrol-origin: margin;
-    }
-    
-    QScrollBar::sub-line:horizontal { /* Vertical - left button position */
-    subcontrol-position:left;
+}
+
+QScrollBar::sub-line:horizontal {
+    /* Vertical - left button position */
+    subcontrol-position: left;
     subcontrol-origin: margin;
-    }
-    
-    QScrollBar::add-line:horizontal { /* Vertical - right button position */
-    subcontrol-position:right;
+}
+
+QScrollBar::add-line:horizontal {
+    /* Vertical - right button position */
+    subcontrol-position: right;
     subcontrol-origin: margin;
-    }
-    
-    QScrollBar:up-arrow, QScrollBar:down-arrow, QScrollBar:left-arrow, QScrollBar:right-arrow { /* Arrows Icon */
-    width:10px;
-    height:10px;
-    }
-    
-    QScrollBar:up-arrow {
+}
+
+QScrollBar:up-arrow, QScrollBar:down-arrow, QScrollBar:left-arrow, QScrollBar:right-arrow {
+    /* Arrows Icon */
+    width: 10px;
+    height: 10px;
+}
+
+QScrollBar:up-arrow {
     background-image: url(':/images/upArrow_small');
-    }
-    
-    QScrollBar:down-arrow {
+}
+
+QScrollBar:down-arrow {
     background-image: url(':/images/downArrow_small');
-    }
-    
-    QScrollBar:left-arrow {
+}
+
+QScrollBar:left-arrow {
     background-image: url(':/images/leftArrow_small');
-    }
-    
-    QScrollBar:right-arrow {
+}
+
+QScrollBar:right-arrow {
     background-image: url(':/images/rightArrow_small');
-    }
-    
-    QSlider::groove:horizontal {
+}
+
+QSlider::groove:horizontal {
     border: 1px solid #bbb;
     background: white;
     height: 6px;
     border-radius: 4px;
-    }
-    
-    QSlider::sub-page:horizontal {
+}
+
+QSlider::sub-page:horizontal {
     /* background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #4b864b, stop: 1 #7b67a9); */
     background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #7ac77a, stop: 1 #98f698);
     border: 1px solid #333;
     height: 10px;
     border-radius: 4px;
-    }
-    
-    QSlider::add-page:horizontal {
+}
+
+QSlider::add-page:horizontal {
     background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #4c7b4c, stop: 1 #7ac77a);
     border: 1px solid #333;
     height: 10px;
     border-radius: 4px;
-    }
-    
-    QSlider::handle:horizontal {
+}
+
+QSlider::handle:horizontal {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #fff, stop:1 #f8f6f6);
     border: 1px solid #333;
     width: 18px;
@@ -591,9 +625,9 @@ WalletFrame {
     margin-top: -6px;
     margin-bottom: -6px;
     border-radius: 9px;
-    }
-    
-    QSlider::handle:horizontal:hover {
+}
+
+QSlider::handle:horizontal:hover {
     background-color: qradialgradient(cx: 0.5, cy: 0.5, fx: 0.5, fy: 0.5, radius: 0.7, stop: 0 #4c7b4c, stop: 0.7 #ffffff);
     border: 2px solid #333;
     width: 16px;
@@ -601,1141 +635,1291 @@ WalletFrame {
     margin-top: -6px;
     margin-bottom: -6px;
     border-radius: 8px;
-    }
-    
-    /**************************** DIALOG BOXES **********************************************/
-    
-    QDialog {
+}
+
+/**************************** DIALOG BOXES **********************************************/
+
+QDialog {
     background-color: #fff;
-    }
-    AskPassphraseDialog {
+}
+
+AskPassphraseDialog {
     background-color: #fff;
-    }
-    
-    
-    QDialog .QTabWidget {
-    border-bottom:1px solid #333;
-    }
-    
-    QDialog .QTabWidget::pane {
+}
+
+QDialog .QTabWidget {
+    border-bottom: 1px solid #333;
+}
+
+QDialog .QTabWidget::pane {
     border: 1px solid #d7d7d7;
-    }
-    
-    QDialog .QTabWidget QTabBar::tab {
-    background-color:#f8f6f6;
-    color:#333;
-    padding-left:10px;
-    padding-right:10px;
-    padding-top:5px;
-    padding-bottom:5px;
+}
+
+QDialog .QTabWidget QTabBar::tab {
+    background-color: #f8f6f6;
+    color: #333;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 5px;
+    padding-bottom: 5px;
     border-top: 1px solid #d7d7d7;
-    }
-    
-    QDialog .QTabWidget QTabBar::tab:first {
+}
+
+QDialog .QTabWidget QTabBar::tab:first {
     border-left: 1px solid #d7d7d7;
-    }
-    
-    QDialog .QTabWidget QTabBar::tab:last {
+}
+
+QDialog .QTabWidget QTabBar::tab:last {
     border-right: 1px solid #d7d7d7;
-    }
-    
-    QDialog .QTabWidget QTabBar::tab:selected, QDialog .QTabWidget QTabBar::tab:hover {
-    background-color:#ffffff;
-    color:#333;
-    }
-    
-    QDialog .QTabWidget .QWidget {
-    background-color:#fff;
-    color:#333;
-    }
-    
-    QDialog .QTabWidget .QWidget QAbstractSpinBox {
-    min-height:15px;
-    }
-    
-    QDialog .QTabWidget .QWidget QAbstractSpinBox::down-button {
-    width:15px;
-    }
-    
-    QDialog .QTabWidget .QWidget QAbstractSpinBox::up-button {
-    width:15px;
-    }
-    
-    QDialog .QTabWidget .QWidget QComboBox {
-    min-height:15px;
-    }
-    
-    /**************************** FILE MENU *************************************************/
-    
-    /* Dialog: Open URI */
-    QDialog#OpenURIDialog QLabel#label { /* URI Label */
-    font-weight:bold;
-    }
-    
-    QDialog#OpenURIDialog QPushButton#selectFileButton { /* ... Button */
-    background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
-    border:1px solid #d2d2d2;
-    color:#616161;
-    padding-left:10px;
-    padding-right:10px;
-    }
-    
-    QDialog#OpenURIDialog QPushButton#selectFileButton:hover {
-    background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(240, 240, 240, 255), stop: .95 rgba(240, 240, 240, 255), stop: 1 #ebebeb);
-    color:#333;
-    }
-    
-    QDialog#OpenURIDialog QPushButton#selectFileButton:pressed {
-    border:1px solid #9e9e9e;
-    }
-    
-    /**************************** SIGN/ VERIFY MESSAGE DIALOG *******************************/
-    
-    /* QDialog#SignVerifyMessageDialog QPushButton#addressBookButton_SM { /* Address Book Button */
-    /* QDialog#SignVerifyMessageDialog QPlainTextEdit { /* Message Signing Text */
-    /* QDialog#SignVerifyMessageDialog QPushButton#pasteButton_SM { /* Paste Button */
-    /* QDialog#SignVerifyMessageDialog QLineEdit:!focus { /* Font Hack */
-    /* QDialog#SignVerifyMessageDialog QPushButton#copySignatureButton_SM { /* Copy Button */
-    /* QDialog#SignVerifyMessageDialog QPushButton#clearButton_SM { /* Clear Button */
-    /* QDialog#SignVerifyMessageDialog QPushButton#addressBookButton_VM { /* Verify Message - Address Book Button */
-    /* QDialog#SignVerifyMessageDialog QPushButton#clearButton_VM { /* Verify Message - Clear Button */
-    
-    /**************************** SEND AND RECEIVE ADDRESSES DIALOG *****************************/
-    
-    QWidget#AddressBookPage {
-    background-color:#F8F6F6;
-    }
-    
-    /* QWidget#AddressBookPage QPushButton#newAddress { /* New Address Button */
-    /* QWidget#AddressBookPage QPushButton#copyAddress { /* Copy Address Button */
-    /* QWidget#AddressBookPage QPushButton#deleteAddress { /* Delete Address Button */
-    
-    QWidget#AddressBookPage QTableView { /* Address Listing */
-    font-size:12px;
-    }
-    
-    QWidget#AddressBookPage QHeaderView::section { /* Min width for Windows fix */
-    min-width:260px;
-    }
-    
-    /**************************** MultiSig Dialog *******************************************/
-    
-    /* QDialog#MultisigDialog QPushButton { */
-    /* QDialog#MultisigDialog QFrame#addressFrame { */
-    
-    /**************************** Privacy Dialog ********************************************/
-    
-    
-    QWidget#PrivacyDialog QFrame {
-    background-color:transparent;
-    border:0px solid #000;
-    }
-    
-    QWidget#PrivacyDialog QFrame#labelMintStatus {
-    background-color:#eee;
+}
+
+QDialog .QTabWidget QTabBar::tab:selected, QDialog .QTabWidget QTabBar::tab:hover {
+    background-color: #ffffff;
+    color: #333;
+}
+
+QDialog .QTabWidget .QWidget {
+    background-color: #fff;
+    color: #333;
+}
+
+QDialog .QTabWidget .QWidget QAbstractSpinBox {
+    min-height: 15px;
+}
+
+QDialog .QTabWidget .QWidget QAbstractSpinBox::down-button {
+    width: 15px;
+}
+
+QDialog .QTabWidget .QWidget QAbstractSpinBox::up-button {
+    width: 15px;
+}
+
+QDialog .QTabWidget .QWidget QComboBox {
+    min-height: 15px;
+}
+
+/**************************** FILE MENU *************************************************/
+
+/* Dialog: Open URI */
+
+QDialog#OpenURIDialog QLabel#label {
+    /* URI Label */
+    font-weight: bold;
+}
+
+QDialog#OpenURIDialog QPushButton#selectFileButton {
+    /* ... Button */
+    background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
+    border: 1px solid #d2d2d2;
+    color: #616161;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+QDialog#OpenURIDialog QPushButton#selectFileButton:hover {
+    background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(240, 240, 240, 255), stop: .95 rgba(240, 240, 240, 255), stop: 1 #ebebeb);
+    color: #333;
+}
+
+QDialog#OpenURIDialog QPushButton#selectFileButton:pressed {
+    border: 1px solid #9e9e9e;
+}
+
+/**************************** SIGN/ VERIFY MESSAGE DIALOG *******************************/
+
+/* QDialog#SignVerifyMessageDialog QPushButton#addressBookButton_SM { /* Address Book Button */
+
+/* QDialog#SignVerifyMessageDialog QPlainTextEdit { /* Message Signing Text */
+
+/* QDialog#SignVerifyMessageDialog QPushButton#pasteButton_SM { /* Paste Button */
+
+/* QDialog#SignVerifyMessageDialog QLineEdit:!focus { /* Font Hack */
+
+/* QDialog#SignVerifyMessageDialog QPushButton#copySignatureButton_SM { /* Copy Button */
+
+/* QDialog#SignVerifyMessageDialog QPushButton#clearButton_SM { /* Clear Button */
+
+/* QDialog#SignVerifyMessageDialog QPushButton#addressBookButton_VM { /* Verify Message - Address Book Button */
+
+/* QDialog#SignVerifyMessageDialog QPushButton#clearButton_VM { /* Verify Message - Clear Button */
+
+/**************************** SEND AND RECEIVE ADDRESSES DIALOG *****************************/
+
+QWidget#AddressBookPage {
+    background-color: #F8F6F6;
+}
+
+/* QWidget#AddressBookPage QPushButton#newAddress { /* New Address Button */
+
+/* QWidget#AddressBookPage QPushButton#copyAddress { /* Copy Address Button */
+
+/* QWidget#AddressBookPage QPushButton#deleteAddress { /* Delete Address Button */
+
+QWidget#AddressBookPage QTableView {
+    /* Address Listing */
+    font-size: 12px;
+}
+
+QWidget#AddressBookPage QHeaderView::section {
+    /* Min width for Windows fix */
+    min-width: 260px;
+}
+
+/**************************** MultiSig Dialog *******************************************/
+
+/* QDialog#MultisigDialog QPushButton { */
+
+/* QDialog#MultisigDialog QFrame#addressFrame { */
+
+/**************************** Privacy Dialog ********************************************/
+
+QWidget#PrivacyDialog QFrame {
+    background-color: transparent;
+    border: 0px solid #000;
+}
+
+QWidget#PrivacyDialog QFrame#labelMintStatus {
+    background-color: #eee;
     border: 1px inset gray;
-    }
-    
-    QWidget#PrivacyDialog QLabel {
-    border:0px solid #000;
-    }
-    
-    QWidget#PrivacyDialog QLabel#zPIVLabel {
-    font-size:14px;
-    color:#ffffff;
-    background-color:#4c7b4c;
-    }
-    
-    QWidget#PrivacyDialog QLabel#oPIVLabel {
-    font-size:14px;
-    color:#ffffff;
-    background-color:#4c7b4c;
-    }
-    
-    QWidget#PrivacyDialog QPushButton {
-    font-size:12px;
-    font-weight:normal;
-    padding-left:5px;
-    padding-right:5px;
-    padding-top:1px;
-    padding-bottom:1px;
+}
+
+QWidget#PrivacyDialog QLabel {
+    border: 0px solid #000;
+}
+
+QWidget#PrivacyDialog QLabel#zPIVLabel {
+    font-size: 14px;
+    color: #ffffff;
+    background-color: #4c7b4c;
+}
+
+QWidget#PrivacyDialog QLabel#oPIVLabel {
+    font-size: 14px;
+    color: #ffffff;
+    background-color: #4c7b4c;
+}
+
+QWidget#PrivacyDialog QPushButton {
+    font-size: 12px;
+    font-weight: normal;
+    padding-left: 5px;
+    padding-right: 5px;
+    padding-top: 1px;
+    padding-bottom: 1px;
     height: 26px;
     margin: 2px;
-    }
-    
-    QWidget#PrivacyDialog QProgressBar#obfuscationProgress { /* Obfuscation Completion */
+}
+
+QWidget#PrivacyDialog QProgressBar#obfuscationProgress {
+    /* Obfuscation Completion */
     border: 1px solid #818181;
     border-radius: 1px;
-    margin-right:43px;
+    margin-right: 43px;
     text-align: right;
-    color:#818181;
-    }
-    
-    QWidget#PrivacyDialog QProgressBar#obfuscationProgress::chunk {
+    color: #818181;
+}
+
+QWidget#PrivacyDialog QProgressBar#obfuscationProgress::chunk {
     background-color: #304530;
-    width:1px;
-    }
-    
-    /**************************** SETTINGS MENU *********************************************/
-    
-    /* Encrypt Wallet and Change Passphrase Dialog */
-    QDialog#AskPassphraseDialog QLabel#passLabel1, QDialog#AskPassphraseDialog QLabel#passLabel2, QDialog#AskPassphraseDialog QLabel#passLabel3 {
+    width: 1px;
+}
+
+/**************************** SETTINGS MENU *********************************************/
+
+/* Encrypt Wallet and Change Passphrase Dialog */
+
+QDialog#AskPassphraseDialog QLabel#passLabel1, QDialog#AskPassphraseDialog QLabel#passLabel2, QDialog#AskPassphraseDialog QLabel#passLabel3 {
     qproperty-alignment: 'AlignVCenter | AlignRight';
-    }
-    
-    /* Options Dialog */
-    QDialog#OptionsDialog QValueComboBox, QDialog#OptionsDialog QSpinBox {
-    margin-top:5px;
-    margin-bottom:5px;
-    }
-    
-    QDialog#OptionsDialog QValidatedLineEdit, QDialog#OptionsDialog QValidatedLineEdit:disabled, QDialog#OptionsDialog QLineEdit, QDialog#OptionsDialog QLineEdit:disabled {
+}
+
+/* Options Dialog */
+
+QDialog#OptionsDialog QValueComboBox, QDialog#OptionsDialog QSpinBox {
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+QDialog#OptionsDialog QValidatedLineEdit, QDialog#OptionsDialog QValidatedLineEdit:disabled, QDialog#OptionsDialog QLineEdit, QDialog#OptionsDialog QLineEdit:disabled {
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-height:20px;
-    margin-top:0px;
-    margin-bottom:0px;
-    padding-top:1px;
-    padding-bottom:1px;
-    }
-    
-    QDialog#OptionsDialog > QLabel {
+    min-height: 20px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    padding-top: 1px;
+    padding-bottom: 1px;
+}
+
+QDialog#OptionsDialog>QLabel {
     qproperty-alignment: 'AlignVCenter';
-    min-height:20px;
-    }
-    
-    QDialog#OptionsDialog QWidget#tabDisplay QValueComboBox {
-    margin-top:0px;
-    margin-bottom:0px;
-    }
-    
-    QDialog#OptionsDialog QLabel#label_3 { /* Translations Missing? Label */
+    min-height: 20px;
+}
+
+QDialog#OptionsDialog QWidget#tabDisplay QValueComboBox {
+    margin-top: 0px;
+    margin-bottom: 0px;
+}
+
+QDialog#OptionsDialog QLabel#label_3 {
+    /* Translations Missing? Label */
     qproperty-alignment: 'AlignVCenter | AlignCenter';
-    color:#818181;
-    padding-bottom:8px;
-    }
-    
-    QDialog#OptionsDialog QCheckBox {
-    min-height:20px;
-    }
-    
-    QDialog#OptionsDialog QCheckBox#displayAddresses {
-    min-height:33px;
-    }
-    
-    QDialog#OptionsDialog QLabel#labelStakeSplitThresholdText {
-    font-size:16px;
-    }
-    
-    /**************************** TOOLS MENU ************************************************/
-    
-    QDialog#RPCConsole QWidget#tab_info QLabel#label_11, QDialog#RPCConsole QWidget#tab_info QLabel#label_10 { /* Margin between Network and Block Chain headers */
+    color: #818181;
+    padding-bottom: 8px;
+}
+
+QDialog#OptionsDialog QCheckBox {
+    min-height: 20px;
+}
+
+QDialog#OptionsDialog QCheckBox#displayAddresses {
+    min-height: 33px;
+}
+
+QDialog#OptionsDialog QLabel#labelStakeSplitThresholdText {
+    font-size: 16px;
+}
+
+/**************************** TOOLS MENU ************************************************/
+
+QDialog#RPCConsole QWidget#tab_info QLabel#label_11, QDialog#RPCConsole QWidget#tab_info QLabel#label_10 {
+    /* Margin between Network and Block Chain headers */
     qproperty-alignment: 'AlignBottom';
-    min-height:25px;
-    min-width:180px;
-    }
-    
-    QDialog#RPCConsole QWidget#tab_peers QLabel#peerHeading { /* Peers Info Header */
-    color:#304530;
-    }
-    
-    QDialog#RPCConsole QTableView#peerWidget::item { /* Peers Table Items */
-    color:#333;
-    }
-    
-    QDialog#RPCConsole QPushButton#openDebugLogfileButton {
-    max-width:60px;
-    }
-    
-    QDialog#RPCConsole QTextEdit#messagesWidget { /* Console Messages Window */
-    border:0;
-    background-color:#fcfcfc;
-    color:#333;
-    }
-    
-    QDialog#RPCConsole QLineEdit#lineEdit { /* Console Input */
-    margin-right:5px;
-    }
-    
-    QDialog#RPCConsole QPushButton#clearButton { /* Console Clear Button */
-    background-color:transparent;
-    padding-left:10px;
-    padding-right:10px;
-    }
-    
-    QDialog#RPCConsole .QGroupBox #line { /* Network In Line */
-    background-color:#4c7b4c;
-    }
-    
-    QDialog#RPCConsole .QGroupBox #line_2 { /* Network Out Line */
-    background:#fff;
-    }
-    
-    /**************************** HELP MENU *************************************************/
-    
-    /* Command Line Options Dialog */
-    QDialog#HelpMessageDialog QScrollArea * {
-    background-color:#fff;
-    }
-    
-    QDialog#HelpMessageDialog QScrollBar:vertical, QDialog#HelpMessageDialog QScrollBar:horizontal {
-    border:0;
-    }
-    
-    /* About Pivx Dialog */
-    QDialog#AboutDialog QLabel#label, QDialog#AboutDialog QLabel#copyrightLabel, QDialog#AboutDialog QLabel#label_2 { /* About Pivx Contents */
-    margin-left:10px;
-    }
-    
-    QDialog#AboutDialog QLabel#label_2 { /* Margin for About Pivx text */
-    margin-right:10px;
-    }
-    
-    /* Edit Address Dialog */
-    QDialog#EditAddressDialog QLabel {
+    min-height: 25px;
+    min-width: 180px;
+}
+
+QDialog#RPCConsole QWidget#tab_peers QLabel#peerHeading {
+    /* Peers Info Header */
+    color: #304530;
+}
+
+QDialog#RPCConsole QTableView#peerWidget::item {
+    /* Peers Table Items */
+    color: #333;
+}
+
+QDialog#RPCConsole QPushButton#openDebugLogfileButton {
+    max-width: 60px;
+}
+
+QDialog#RPCConsole QTextEdit#messagesWidget {
+    /* Console Messages Window */
+    border: 0;
+    background-color: #fcfcfc;
+    color: #333;
+}
+
+QDialog#RPCConsole QLineEdit#lineEdit {
+    /* Console Input */
+    margin-right: 5px;
+}
+
+QDialog#RPCConsole QPushButton#clearButton {
+    /* Console Clear Button */
+    background-color: transparent;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+QDialog#RPCConsole .QGroupBox #line {
+    /* Network In Line */
+    background-color: #4c7b4c;
+}
+
+QDialog#RPCConsole .QGroupBox #line_2 {
+    /* Network Out Line */
+    background: #fff;
+}
+
+/**************************** HELP MENU *************************************************/
+
+/* Command Line Options Dialog */
+
+QDialog#HelpMessageDialog QScrollArea * {
+    background-color: #fff;
+}
+
+QDialog#HelpMessageDialog QScrollBar:vertical, QDialog#HelpMessageDialog QScrollBar:horizontal {
+    border: 0;
+}
+
+/* About Pivx Dialog */
+
+QDialog#AboutDialog QLabel#label, QDialog#AboutDialog QLabel#copyrightLabel, QDialog#AboutDialog QLabel#label_2 {
+    /* About Pivx Contents */
+    margin-left: 10px;
+}
+
+QDialog#AboutDialog QLabel#label_2 {
+    /* Margin for About Pivx text */
+    margin-right: 10px;
+}
+
+/* Edit Address Dialog */
+
+QDialog#EditAddressDialog QLabel {
     qproperty-alignment: 'AlignVCenter | AlignRight';
-    min-height:27px;
-    font-weight:normal;
-    padding-right:5px;
-    }
-    
-    /* Header design for ALL tabs/pages *****************************************************/
-    /* Horizontal lines */
-    QFrame[frameShape="4"] { /* QFrame::HLine == 0x0004 */
-    border:1px solid #004d00;
-    }
-    
-    /* Headers */
-    QLabel#labelOverviewHeaderLeft {
-    font-weight:bold;
-    font-size:20px;
-    background-color:#ffffff;
-    }
-    
-    QLabel#labelOverviewHeaderRight {
+    min-height: 27px;
+    font-weight: normal;
+    padding-right: 5px;
+}
+
+/* Header design for ALL tabs/pages *****************************************************/
+
+/* Horizontal lines */
+
+QFrame[frameShape="4"] {
+    /* QFrame::HLine == 0x0004 */
+    border: 1px solid #004d00;
+}
+
+/* Headers */
+
+QLabel#labelOverviewHeaderLeft {
+    font-weight: bold;
+    font-size: 20px;
+    background-color: #ffffff;
+}
+
+QLabel#labelOverviewHeaderRight {
     qproperty-alignment: 'AlignVCenter | AlignRight';
     background-image: url(':/images/pivx_logo_horizontal');
     background-repeat: no-repeat;
-    }
-    
-    QWidget .QFrame#frame_Header { /* Header with Page-Title and PIVX-image */
-    min-width:400px;
-    background-color:#ffffff;
-    }
-    
-    QWidget .QFrame#frame_BG { /* Background */
-    min-width:400px;
-    background-color:#f8f6f6;
-    }
-    
-    /**************************** OVERVIEW SCREEN *******************************************/
-    
-    QWidget .QFrame#frame_Space { /* Space between Header and Content */
-    min-width:400px;
-    background-color:#f8f6f6;
-    }
-    
-    QWidget .QFrame#frame_Content { /* Actual Content */
-    min-width:400px;
-    background-color:#f8f6f6;
-    }
-    
-    QWidget .QFrame#frame_Balances { /* Upper left side */
-    min-width:400px;
-    background-color:#ffffff;
-    }
-    
-    QWidget .QFrame#frame_ZerocoinBalances { /* Lower left side */
-    min-width:400px;
-    background-color:#ffffff;
-    }
-    
-    QWidget .QFrame#frame_CombinedBalances { /* Lower left side */
-    min-width:400px;
-    background-color:#ffffff;
-    }
-    
-    QWidget .QFrame#frame_RecentTransactions { /* Right side */
-    min-width:400px;
-    background-color:#ffffff;
-    }
-    
-    QWidget .QFrame#frame_Balances > .QLabel {
-    min-width:190px;
-    font-weight:normal;
+}
+
+QWidget .QFrame#frame_Header {
+    /* Header with Page-Title and PIVX-image */
+    min-width: 400px;
+    background-color: #ffffff;
+}
+
+QWidget .QFrame#frame_BG {
+    /* Background */
+    min-width: 400px;
+    background-color: #f8f6f6;
+}
+
+/**************************** OVERVIEW SCREEN *******************************************/
+
+QWidget .QFrame#frame_Space {
+    /* Space between Header and Content */
+    min-width: 400px;
+    background-color: #f8f6f6;
+}
+
+QWidget .QFrame#frame_Content {
+    /* Actual Content */
+    min-width: 400px;
+    background-color: #f8f6f6;
+}
+
+QWidget .QFrame#frame_Balances {
+    /* Upper left side */
+    min-width: 400px;
+    background-color: #ffffff;
+}
+
+QWidget .QFrame#frame_ZerocoinBalances {
+    /* Lower left side */
+    min-width: 400px;
+    background-color: #ffffff;
+}
+
+QWidget .QFrame#frame_CombinedBalances {
+    /* Lower left side */
+    min-width: 400px;
+    background-color: #ffffff;
+}
+
+QWidget .QFrame#frame_RecentTransactions {
+    /* Right side */
+    min-width: 400px;
+    background-color: #ffffff;
+}
+
+QWidget .QFrame#frame_Balances>.QLabel {
+    min-width: 190px;
+    font-weight: normal;
     /* min-height:30px; */
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#label_5 { /* PIV Balances Label */
+}
+
+QWidget .QFrame#frame_Balances .QLabel#label_5 {
+    /* PIV Balances Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    background-color:transparent;
-    color:#304530;
-    font-weight:bold;
-    font-size:14px;
-    margin-right:5px;
-    padding-right:5px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelWalletStatus { /* Wallet Sync Status */
+    min-width: 160px;
+    background-color: transparent;
+    color: #304530;
+    font-weight: bold;
+    font-size: 14px;
+    margin-right: 5px;
+    padding-right: 5px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelWalletStatus {
+    /* Wallet Sync Status */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    margin-left:3px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelSpendable { /* Spendable Header */
+    margin-left: 3px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelSpendable {
+    /* Spendable Header */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    margin-left:18px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelWatchonly { /* Watch-only Header */
+    font-size: 12px;
+    margin-left: 18px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelWatchonly {
+    /* Watch-only Header */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    margin-left:16px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelBalanceText { /* Available Balance Label */
+    font-size: 12px;
+    margin-left: 16px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelBalanceText {
+    /* Available Balance Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelBalance { /* Available Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelBalance {
+    /* Available Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    font-weight:bold;
-    color:#4c7b4c;
-    margin-left:0px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelWatchAvailable { /* Watch-only Balance */
+    font-size: 12px;
+    font-weight: bold;
+    color: #4c7b4c;
+    margin-left: 0px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelWatchAvailable {
+    /* Watch-only Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    margin-left:16px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelPendingText { /* Pending Balance Label */
+    font-size: 12px;
+    margin-left: 16px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelPendingText {
+    /* Pending Balance Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelUnconfirmed { /* Pending Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelUnconfirmed {
+    /* Pending Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    font-weight:bold;
-    color:#4c7b4c;
-    margin-left:0px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelWatchPending { /* Watch-only Pending Balance */
+    font-size: 12px;
+    font-weight: bold;
+    color: #4c7b4c;
+    margin-left: 0px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelWatchPending {
+    /* Watch-only Pending Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    margin-left:16px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelImmatureText { /* Immature Balance Label */
+    font-size: 12px;
+    margin-left: 16px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelImmatureText {
+    /* Immature Balance Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelImmature { /* Immature Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelImmature {
+    /* Immature Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    font-weight:bold;
-    color:#4c7b4c;
-    margin-left:0px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelWatchImmature { /* Watch-only Immature Balance */
+    font-size: 12px;
+    font-weight: bold;
+    color: #4c7b4c;
+    margin-left: 0px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelWatchImmature {
+    /* Watch-only Immature Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    margin-left:16px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelTotalText { /* Total Balance Label */
+    font-size: 12px;
+    margin-left: 16px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelTotalText {
+    /* Total Balance Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelTotal { /* Total Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelTotal {
+    /* Total Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    font-weight:bold;
-    color:#4c7b4c;
-    margin-left:0px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelWatchTotal { /* Watch-only Total Balance */
+    font-size: 12px;
+    font-weight: bold;
+    color: #4c7b4c;
+    margin-left: 0px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelWatchTotal {
+    /* Watch-only Total Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    margin-left:16px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelLockedBalanceText { /* Available zPIV Label */
+    font-size: 12px;
+    margin-left: 16px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelLockedBalanceText {
+    /* Available zPIV Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelLockedBalance { /* Available zPIV Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelLockedBalance {
+    /* Available zPIV Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    font-weight:bold;
-    color:#4c7b4c;
-    margin-left:0px;
-    }
-    
-    QWidget .QFrame#frame_Balances .QLabel#labelWatchLocked { /* Available zPIV Balance */
+    font-size: 12px;
+    font-weight: bold;
+    color: #4c7b4c;
+    margin-left: 0px;
+}
+
+QWidget .QFrame#frame_Balances .QLabel#labelWatchLocked {
+    /* Available zPIV Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    margin-left:16px;
-    }
-    
-    /* Zerocoin additions start here ***********************************************/
-    
-    QWidget .QFrame#frame_ZerocoinBalances .QLabel#label_5z_3 { /* Zerocoin Balance Label */
+    font-size: 12px;
+    margin-left: 16px;
+}
+
+/* Zerocoin additions start here ***********************************************/
+
+QWidget .QFrame#frame_ZerocoinBalances .QLabel#label_5z_3 {
+    /* Zerocoin Balance Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    background-color:transparent;
-    color:#304530;
-    font-weight:bold;
-    font-size:14px;
-    margin-right:5px;
-    padding-right:5px;
-    }
-    
-    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceText { /* Available zPIV Label */
+    min-width: 160px;
+    background-color: transparent;
+    color: #304530;
+    font-weight: bold;
+    font-size: 14px;
+    margin-right: 5px;
+    padding-right: 5px;
+}
+
+QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceText {
+    /* Available zPIV Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalance { /* Available zPIV Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalance {
+    /* Available zPIV Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    font-weight:bold;
-    color:#4c7b4c;
-    margin-left:0px;
-    }
-    
-    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceUnconfirmedText { /* Unconfirmed zPIV Label */
+    font-size: 12px;
+    font-weight: bold;
+    color: #4c7b4c;
+    margin-left: 0px;
+}
+
+QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceUnconfirmedText {
+    /* Unconfirmed zPIV Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceUnconfirmed { /* Unconfirmed zPIV Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceUnconfirmed {
+    /* Unconfirmed zPIV Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    font-weight:bold;
-    color:#4c7b4c;
-    margin-left:0px;
-    }
-    
-    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceMatureText { /* Mature zPIV Label */
+    font-size: 12px;
+    font-weight: bold;
+    color: #4c7b4c;
+    margin-left: 0px;
+}
+
+QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceMatureText {
+    /* Mature zPIV Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceMature { /* Mature zPIV Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceMature {
+    /* Mature zPIV Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    font-weight:bold;
-    color:#4c7b4c;
-    margin-left:0px;
-    }
-    
-    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceImmatureText { /* Immature zPIV Label */
+    font-size: 12px;
+    font-weight: bold;
+    color: #4c7b4c;
+    margin-left: 0px;
+}
+
+QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceImmatureText {
+    /* Immature zPIV Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceImmature { /* Immature zPIV Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalanceImmature {
+    /* Immature zPIV Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    font-weight:bold;
-    color:#4c7b4c;
-    margin-left:0px;
-    }
-    
-    QWidget .QFrame#frame_CombinedBalances .QLabel#label_5z { /* Combined Balance Label */
+    font-size: 12px;
+    font-weight: bold;
+    color: #4c7b4c;
+    margin-left: 0px;
+}
+
+QWidget .QFrame#frame_CombinedBalances .QLabel#label_5z {
+    /* Combined Balance Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    background-color:transparent;
-    color:#304530;
-    font-weight:bold;
-    font-size:14px;
-    margin-right:5px;
-    padding-right:5px;
-    }
-    
-    QWidget .QFrame#frame_CombinedBalances .QLabel#labelBalanceTextz { /* Available PIV Label */
+    min-width: 160px;
+    background-color: transparent;
+    color: #304530;
+    font-weight: bold;
+    font-size: 14px;
+    margin-right: 5px;
+    padding-right: 5px;
+}
+
+QWidget .QFrame#frame_CombinedBalances .QLabel#labelBalanceTextz {
+    /* Available PIV Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_CombinedBalances .QLabel#labelBalancez { /* Available PIV Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_CombinedBalances .QLabel#labelBalancez {
+    /* Available PIV Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:26px;
-    font-weight:normal;
-    color:#004d00;
-    }
-    
-    QWidget .QFrame#frame_CombinedBalances .QLabel#labelzBalanceTextz { /* Available zPIV Label */
+    font-size: 26px;
+    font-weight: normal;
+    color: #004d00;
+}
+
+QWidget .QFrame#frame_CombinedBalances .QLabel#labelzBalanceTextz {
+    /* Available zPIV Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_CombinedBalances .QLabel#labelzBalancez { /* Available zPIV Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_CombinedBalances .QLabel#labelzBalancez {
+    /* Available zPIV Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:12px;
-    font-weight:bold;
-    color:#4c7b4c;
-    margin-left:0px;
-    }
-    
-    QWidget .QFrame#frame_CombinedBalances .QLabel#labelTotalTextz { /* Available total Label */
+    font-size: 12px;
+    font-weight: bold;
+    color: #4c7b4c;
+    margin-left: 0px;
+}
+
+QWidget .QFrame#frame_CombinedBalances .QLabel#labelTotalTextz {
+    /* Available total Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    color:#004d00;
-    margin-right:5px;
-    padding-right:5px;
-    font-weight:bold;
-    font-size:12px;
-    }
-    
-    QWidget .QFrame#frame_CombinedBalances .QLabel#labelTotalz { /* Available total Balance */
+    min-width: 160px;
+    color: #004d00;
+    margin-right: 5px;
+    padding-right: 5px;
+    font-weight: bold;
+    font-size: 12px;
+}
+
+QWidget .QFrame#frame_CombinedBalances .QLabel#labelTotalz {
+    /* Available total Balance */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    font-size:26px;
-    font-weight:normal;
-    color:#004d00;
-    }
-    
-    /**************************** RECENT TRANSACTIONS ***************************************/
-    
-    QWidget .QFrame#frame_RecentTransactions { /* Transactions Widget */
-    min-width:410px;
-    min-height:100px;
-    margin-left:0;
-    margin-top:0;
-    }
-    
-    QWidget .QFrame#frame_RecentTransactions .QLabel#label_4 { /* Recent Transactions Label */
+    font-size: 26px;
+    font-weight: normal;
+    color: #004d00;
+}
+
+/**************************** RECENT TRANSACTIONS ***************************************/
+
+QWidget .QFrame#frame_RecentTransactions {
+    /* Transactions Widget */
+    min-width: 410px;
+    min-height: 100px;
+    margin-left: 0;
+    margin-top: 0;
+}
+
+QWidget .QFrame#frame_RecentTransactions .QLabel#label_4 {
+    /* Recent Transactions Label */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:180px;
-    background-color:transparent;
-    color:#304530;
-    font-weight:bold;
-    font-size:14px;
-    margin-right:5px;
-    padding-right:5px;
-    }
-    
-    QWidget .QFrame#frame_RecentTransactions .QLabel#labelTransactionsStatus { /* Recent Transactions Sync Status */
+    min-width: 180px;
+    background-color: transparent;
+    color: #304530;
+    font-weight: bold;
+    font-size: 14px;
+    margin-right: 5px;
+    padding-right: 5px;
+}
+
+QWidget .QFrame#frame_RecentTransactions .QLabel#labelTransactionsStatus {
+    /* Recent Transactions Sync Status */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    margin-left:3px;
-    }
-    
-    QWidget .QFrame#frame_RecentTransactions QListView { /* Transaction List */
-    font-weight:normal;
-    font-size:12px;
-    max-width:369px;
-    margin-top:12px;
-    margin-left:0px; /* CSS Voodoo - set to -66px to hide default transaction icons */
-    }
-    
-    /**************************** SEND DIALOG ***********************************************/
-    
-    QDialog#SendCoinsDialog {
-    background-color:#fff;
-    }
-    
-    QDialog#SendCoinsDialog .QFrame#frameCoinControl { /* Coin Control Section */
-    background-color:#ffffff;
-    }
-    
-    QDialog#SendCoinsDialog .QFrame#frameFee { /* Coin Control Section */
-    background-color:#ffffff;
-    }
-    
-    QDialog#SendCoinsDialog .QFrame#frame_Send { /* Coin Control Section */
-    background-color:#ffffff;
-    margin-bottom:6px;
-    }
-    
-    QDialog#SendCoinsDialog .QFrame#frameCoinControl { /* Coin Control Section */
+    margin-left: 3px;
+}
+
+QWidget .QFrame#frame_RecentTransactions QListView {
+    /* Transaction List */
+    font-weight: normal;
+    font-size: 12px;
+    max-width: 369px;
+    margin-top: 12px;
+    margin-left: 0px;
+    /* CSS Voodoo - set to -66px to hide default transaction icons */
+}
+
+/**************************** SEND DIALOG ***********************************************/
+
+QDialog#SendCoinsDialog {
+    background-color: #fff;
+}
+
+QDialog#SendCoinsDialog .QFrame#frameCoinControl {
+    /* Coin Control Section */
+    background-color: #ffffff;
+}
+
+QDialog#SendCoinsDialog .QFrame#frameFee {
+    /* Coin Control Section */
+    background-color: #ffffff;
+}
+
+QDialog#SendCoinsDialog .QFrame#frame_Send {
+    /* Coin Control Section */
+    background-color: #ffffff;
+    margin-bottom: 6px;
+}
+
+QDialog#SendCoinsDialog .QFrame#frameCoinControl {
+    /* Coin Control Section */
     /* background-color:#ffff00; */
-    }
-    
-    QDialog#SendCoinsDialog .QFrame#frameCoinControl > .QLabel { /* Default Font Color and  Size */
-    font-weight:normal;
-    }
-    
-    QDialog#SendCoinsDialog .QFrame#frameCoinControl .QPushButton#pushButtonCoinControl { /* Coin Control Inputs Button */
-    padding-left:10px;
-    padding-right:10px;
-    min-height:25px;
-    }
-    
-    QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlFeatures { /* Coin Control Header */
+}
+
+QDialog#SendCoinsDialog .QFrame#frameCoinControl>.QLabel {
+    /* Default Font Color and  Size */
+    font-weight: normal;
+}
+
+QDialog#SendCoinsDialog .QFrame#frameCoinControl .QPushButton#pushButtonCoinControl {
+    /* Coin Control Inputs Button */
+    padding-left: 10px;
+    padding-right: 10px;
+    min-height: 25px;
+}
+
+QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlFeatures {
+    /* Coin Control Header */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    min-width:160px;
-    background-color:transparent;
-    color:#304530;
-    font-weight:bold;
-    font-size:14px;
-    margin-right:5px;
-    padding-right:5px;
-    }
-    
-    QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl { /* Coin Control Inputs */
-    }
-    
-    QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl > .QLabel { /* Coin Control Inputs Labels */
-    padding:2px;
-    }
-    
-    /* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QCheckBox#checkBoxCoinControlChange { /* Custom Change Label */
-    /* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QValidatedLineEdit#lineEditCoinControlChange { /* Custom Change Address */
-    /* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QValidatedLineEdit#lineEditCoinControlChange:!focus { /* Custom Change Address */
-    /* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLineEdit#splitBlockLineEdit { */
-    /* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLineEdit#splitBlockLineEdit:!focus { /* TX Splitter */
-    
-    QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlChangeLabel { /* Custom Change Address Validation Label */
-    font-weight:normal;
-    }
-    
-    QDialog#SendCoinsDialog .QScrollArea#scrollArea .QWidget#scrollAreaWidgetContents { /* Send To Widget */
-    background-color:#ffffff;
-    }
-    
-    
-    
-    QDialog#SendCoinsDialog .QCheckBox#checkUseObfuscation { /* Obfuscation Checkbox */
-    color:#616161;
-    font-weight:bold;
+    min-width: 160px;
+    background-color: transparent;
+    color: #304530;
+    font-weight: bold;
+    font-size: 14px;
+    margin-right: 5px;
+    padding-right: 5px;
+}
+
+QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl {
+    /* Coin Control Inputs */
+}
+
+QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl>.QLabel {
+    /* Coin Control Inputs Labels */
+    padding: 2px;
+}
+
+/* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QCheckBox#checkBoxCoinControlChange { /* Custom Change Label */
+
+/* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QValidatedLineEdit#lineEditCoinControlChange { /* Custom Change Address */
+
+/* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QValidatedLineEdit#lineEditCoinControlChange:!focus { /* Custom Change Address */
+
+/* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLineEdit#splitBlockLineEdit { */
+
+/* QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLineEdit#splitBlockLineEdit:!focus { /* TX Splitter */
+
+QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlChangeLabel {
+    /* Custom Change Address Validation Label */
+    font-weight: normal;
+}
+
+QDialog#SendCoinsDialog .QScrollArea#scrollArea .QWidget#scrollAreaWidgetContents {
+    /* Send To Widget */
+    background-color: #ffffff;
+}
+
+QDialog#SendCoinsDialog .QCheckBox#checkUseObfuscation {
+    /* Obfuscation Checkbox */
+    color: #616161;
+    font-weight: bold;
     /*background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));*/
-    border-radius:5px;
-    padding-top:20px;
-    padding-bottom:18px;
-    }
-    
-    QDialog#SendCoinsDialog .QCheckBox#checkSwiftTX { /* SwiftTX Checkbox */
-    color:#616161;
-    font-weight:bold;
+    border-radius: 5px;
+    padding-top: 20px;
+    padding-bottom: 18px;
+}
+
+QDialog#SendCoinsDialog .QCheckBox#checkSwiftTX {
+    /* SwiftTX Checkbox */
+    color: #616161;
+    font-weight: bold;
     /*background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));*/
-    border-radius:5px;
-    padding-top:20px;
-    padding-bottom:18px;
-    margin-left:10px;
-    margin-right:20px;
-    }
-    
-    /* This QLabel uses name = "label" which conflicts with Address Book -> New Address */
-    /* To maximize backwards compatibility this formatting has been removed */
-    
-    QDialog#SendCoinsDialog QLabel#label {
-    min-height:27px;
-    }
-    
-    QDialog#SendCoinsDialog QLabel#labelBalance {
-    margin-left:0px;
-    padding-left:0px;
-    color:#333333;
-    min-height:27px;
-    }
-    
-    /**************************** SEND COINS ENTRY ******************************************/
-    
-    QStackedWidget#SendCoinsEntry .QFrame#SendCoins > .QLabel { /* Send Coin Entry Labels */
-    min-width:10px;
-    font-weight:bold;
-    min-height:25px;
-    margin-right:5px;
-    padding-right:5px;
-    }
-    
-    /* QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo { /* Pay To Input Field */
-    /* QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo:!focus { /* Pay To Input Field */
-    /* QStackedWidget#SendCoinsEntry .QToolButton { /* Pay To Custom ToolButton */
-    /* QStackedWidget#SendCoinsEntry .QToolButton:hover { /* Pay To Custom ToolButton */
-    /* QStackedWidget#SendCoinsEntry .QToolButton:focus { /* Pay To Custom ToolButton */
-    /* QStackedWidget#SendCoinsEntry .QToolButton:pressed { /* Pay To Custom ToolButton */
-    /* QStackedWidget#SendCoinsEntry .QToolButton#addressBookButton { /* Address Book Button */
-    /* QStackedWidget#SendCoinsEntry .QToolButton#pasteButton { */
-    /* QStackedWidget#SendCoinsEntry .QToolButton#deleteButton { */
-    /* QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel { /* Pay To Input Field */
-    /* QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel:!focus { /* Pay To Input Field */
-    
-    /**************************** COIN CONTROL POPUP ****************************************/
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlQuantityText { /* Coin Control Quantity Label */
-    min-height:30px;
-    padding-left:15px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlQuantity { /* Coin Control Quantity */
-    min-height:30px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlBytesText { /* Coin Control Bytes Label */
-    padding-left:15px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlBytes { /* Coin Control Bytes */
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlAmountText { /* Coin Control Amount Label */
-    min-height:30px;
-    padding-left:15px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlAmount { /* Coin Control Amount */
-    min-height:30px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlPriorityText { /* Coin Control Priority Label */
-    padding-left:15px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlPriority { /* Coin Control Priority */
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlFeeText { /* Coin Control Fee Label */
-    min-height:30px;
-    padding-left:15px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlFee { /* Coin Control Fee */
-    min-height:30px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlLowOutputText { /* Coin Control Low Output Label */
-    padding-left:15px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlLowOutput { /* Coin Control Low Output */
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlAfterFeeText { /* Coin Control After Fee Label */
-    min-height:30px;
-    padding-left:15px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlAfterFee { /* Coin Control After Fee */
-    min-height:30px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlChangeText { /* Coin Control Change Label */
-    padding-left:15px;
-    }
-    
-    QDialog#CoinControlDialog .QLabel#labelCoinControlChange { /* Coin Control Change */
-    
-    }
-    
-    QDialog#CoinControlDialog .QFrame#frame .QPushButton#pushButtonSelectAll { /* (un)select all button */
-    padding-left:10px;
-    padding-right:10px;
-    min-height:25px;
-    }
-    
-    QDialog#CoinControlDialog .QFrame#frame .QPushButton#pushButtonToggleLock { /* Toggle lock state button */
-    padding-left:10px;
-    padding-right:10px;
-    min-height:25px;
-    }
-    
-    QDialog#CoinControlDialog .QDialogButtonBox#buttonBox QPushButton { /* Coin Control 'OK' button */
-    }
-    
-    QDialog#CoinControlDialog .QFrame#frame .QRadioButton#radioTreeMode { /* Coin Control Tree Mode Selector */
-    color:#818181;
-    background-color:transparent;
-    }
-    
-    QDialog#CoinControlDialog .QFrame#frame .QRadioButton#radioListMode { /* Coin Control List Mode Selector */
-    color:#818181;
-    background-color:transparent;
-    }
-    
-    QDialog#CoinControlDialog QHeaderView::section:first { /* Bug Fix: the number "1" displays in this table for some reason... */
-    color:transparent;
-    }
-    
-    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget { /* Coin Control Widget Container */
-    outline:0;
-    background-color:#ffffff;
-    border:1px solid #333;
-    }
-    
-    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {
-    }
-    
-    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:selected { /* Coin Control Item (selected) */
-    background-color:#4c7b4c;
-    color:#fff;
-    }
-    
-    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:checked { /* Coin Control Item (checked) */
-    background-color:#f7f7f7;
-    color:#fff;
-    }
-    
-    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:selected { /* Coin Control Branch Icon */
+    border-radius: 5px;
+    padding-top: 20px;
+    padding-bottom: 18px;
+    margin-left: 10px;
+    margin-right: 20px;
+}
+
+/* This QLabel uses name = "label" which conflicts with Address Book -> New Address */
+
+/* To maximize backwards compatibility this formatting has been removed */
+
+QDialog#SendCoinsDialog QLabel#label {
+    min-height: 27px;
+}
+
+QDialog#SendCoinsDialog QLabel#labelBalance {
+    margin-left: 0px;
+    padding-left: 0px;
+    color: #333333;
+    min-height: 27px;
+}
+
+/**************************** SEND COINS ENTRY ******************************************/
+
+QStackedWidget#SendCoinsEntry .QFrame#SendCoins>.QLabel {
+    /* Send Coin Entry Labels */
+    min-width: 10px;
+    font-weight: bold;
+    min-height: 25px;
+    margin-right: 5px;
+    padding-right: 5px;
+}
+
+/* QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo { /* Pay To Input Field */
+
+/* QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo:!focus { /* Pay To Input Field */
+
+/* QStackedWidget#SendCoinsEntry .QToolButton { /* Pay To Custom ToolButton */
+
+/* QStackedWidget#SendCoinsEntry .QToolButton:hover { /* Pay To Custom ToolButton */
+
+/* QStackedWidget#SendCoinsEntry .QToolButton:focus { /* Pay To Custom ToolButton */
+
+/* QStackedWidget#SendCoinsEntry .QToolButton:pressed { /* Pay To Custom ToolButton */
+
+/* QStackedWidget#SendCoinsEntry .QToolButton#addressBookButton { /* Address Book Button */
+
+/* QStackedWidget#SendCoinsEntry .QToolButton#pasteButton { */
+
+/* QStackedWidget#SendCoinsEntry .QToolButton#deleteButton { */
+
+/* QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel { /* Pay To Input Field */
+
+/* QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel:!focus { /* Pay To Input Field */
+
+/**************************** COIN CONTROL POPUP ****************************************/
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlQuantityText {
+    /* Coin Control Quantity Label */
+    min-height: 30px;
+    padding-left: 15px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlQuantity {
+    /* Coin Control Quantity */
+    min-height: 30px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlBytesText {
+    /* Coin Control Bytes Label */
+    padding-left: 15px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlBytes {
+    /* Coin Control Bytes */
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlAmountText {
+    /* Coin Control Amount Label */
+    min-height: 30px;
+    padding-left: 15px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlAmount {
+    /* Coin Control Amount */
+    min-height: 30px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlPriorityText {
+    /* Coin Control Priority Label */
+    padding-left: 15px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlPriority {
+    /* Coin Control Priority */
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlFeeText {
+    /* Coin Control Fee Label */
+    min-height: 30px;
+    padding-left: 15px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlFee {
+    /* Coin Control Fee */
+    min-height: 30px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlLowOutputText {
+    /* Coin Control Low Output Label */
+    padding-left: 15px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlLowOutput {
+    /* Coin Control Low Output */
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlAfterFeeText {
+    /* Coin Control After Fee Label */
+    min-height: 30px;
+    padding-left: 15px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlAfterFee {
+    /* Coin Control After Fee */
+    min-height: 30px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlChangeText {
+    /* Coin Control Change Label */
+    padding-left: 15px;
+}
+
+QDialog#CoinControlDialog .QLabel#labelCoinControlChange {
+    /* Coin Control Change */
+}
+
+QDialog#CoinControlDialog .QFrame#frame .QPushButton#pushButtonSelectAll {
+    /* (un)select all button */
+    padding-left: 10px;
+    padding-right: 10px;
+    min-height: 25px;
+}
+
+QDialog#CoinControlDialog .QFrame#frame .QPushButton#pushButtonToggleLock {
+    /* Toggle lock state button */
+    padding-left: 10px;
+    padding-right: 10px;
+    min-height: 25px;
+}
+
+QDialog#CoinControlDialog .QDialogButtonBox#buttonBox QPushButton {
+    /* Coin Control 'OK' button */
+}
+
+QDialog#CoinControlDialog .QFrame#frame .QRadioButton#radioTreeMode {
+    /* Coin Control Tree Mode Selector */
+    color: #818181;
+    background-color: transparent;
+}
+
+QDialog#CoinControlDialog .QFrame#frame .QRadioButton#radioListMode {
+    /* Coin Control List Mode Selector */
+    color: #818181;
+    background-color: transparent;
+}
+
+QDialog#CoinControlDialog QHeaderView::section:first {
+    /* Bug Fix: the number "1" displays in this table for some reason... */
+    color: transparent;
+}
+
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget {
+    /* Coin Control Widget Container */
+    outline: 0;
+    background-color: #ffffff;
+    border: 1px solid #333;
+}
+
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {}
+
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:selected {
+    /* Coin Control Item (selected) */
+    background-color: #4c7b4c;
+    color: #fff;
+}
+
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:checked {
+    /* Coin Control Item (checked) */
+    background-color: #f7f7f7;
+    color: #fff;
+}
+
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:selected {
+    /* Coin Control Branch Icon */
     background-image: url(':/images/qtreeview_selected');
-    background-repeat:no-repeat;
-    background-position:center;
-    background-color:#f7f7f7;
-    color:#333;
-    }
-    
-    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:checked { /* Coin Control Branch Icon */
+    background-repeat: no-repeat;
+    background-position: center;
+    background-color: #f7f7f7;
+    color: #333;
+}
+
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:checked {
+    /* Coin Control Branch Icon */
     background-image: url(':/images/qtreeview_selected');
-    background-repeat:no-repeat;
-    background-position:center;
-    background-color:#f7f7f7;
-    color:#333;
-    }
-    
-    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::seperator {
-    
-    }
-    
-    QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::indicator { /* Coin Control Widget Checkbox */
-    
-    }
-    
-    QDialog#ZPivControlDialog .QTreeWidget#treeWidget { /* zPIV Control Widget Container */
-    outline:0;
-    background-color:#ffffff;
-    border:1px solid #333;
-    }
-    
-    /**************************** RECEIVE COINS *********************************************/
-    
-    QWidget#ReceiveCoinsDialog {
-    background-color:#fff;
-    }
-    
-    QWidget#ReceiveCoinsDialog .QFrame#frame {
-    background-color:#ffffff;
-    }
-    
-    QWidget#ReceiveCoinsDialog .QFrame#frame2 {
-    background-color:#ffffff;
-    }
-    
-    QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLabel { /* Receive Coin Labels */
-    min-width:10px;
-    font-weight:bold;
-    min-height:25px;
-    margin-right:5px;
-    padding-right:5px;
-    }
-    
-    /* QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLineEdit { /* Receive Coin LineEdits */
-    /* QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLineEdit:!focus { /* Receive Coin LineEdits */
-    
-    QWidget#ReceiveCoinsDialog .QFrame#frame QPushButton { /* Clear Button */
-    padding-left:10px;
-    padding-right:10px;
-    }
-    
-    QWidget#ReceiveCoinsDialog .QFrame#frame QPushButton:pressed {
-    border:1px solid #9e9e9e;
-    }
-    
-    QWidget#ReceiveCoinsDialog .QFrame#frame2 QPushButton { /* Clear Button */
-    padding-left:10px;
-    padding-right:10px;
-    }
-    
-    QWidget#ReceiveCoinsDialog .QFrame#frame2 QPushButton:pressed {
-    border:1px solid #9e9e9e;
-    }
-    
-    QWidget#ReceiveCoinsDialog .QFrame#frame .QLabel#label_6 { /* Requested Payments History Label */
-    color:#304530;
-    font-weight:bold;
-    font-size:14px;
-    }
-    
-    /**************************** RECEIVE COINS DIALOG **************************************/
-    
-    QDialog#ReceiveRequestDialog QTextEdit { /* Contents of Receive Coin Dialog */
-    border:1px solid #d7d7d7;
-    }
-    
-    /**************************** TRANSACTIONS PAGE *****************************************/
-    
-    TransactionView QLineEdit { /* Address Filter */
-    margin-bottom:2px;
-    margin-right:1px;
-    min-width:111px;
-    text-align:center;
-    }
-    
-    TransactionView QComboBox {
-    margin-bottom:1px;
-    margin-right:1px;
-    }
-    
-    QLabel#transactionSumLabel { /* Example of setObjectName for widgets without name */
-    color:#333333;
-    font-weight:bold;
-    }
-    
-    QLabel#transactionSum { /* Example of setObjectName for widgets without name */
-    color:#333333;
-    }
-    
-    /**************************** TRANSACTION DETAILS DIALOG ********************************/
-    
-    QDialog#TransactionDescDialog QTextEdit { /* Contents of Receive Coin Dialog */
-    border:1px solid #d7d7d7;
-    }
-    
-    /**************************** PRIVACY PAGE *****************************************/
-    /* QDialog#PrivacyDialog */
-    /* QWidget#PrivacyDialog */
-    
-    QWidget#PrivacyDialog .QFrame[frameShape="4"] { /* QFrame::HLine == 0x0004 */
-    border:1px solid #004d00;
-    }
-    
-    QWidget#PrivacyDialog .QFrame#frame_Content {
-    background-color:#f8f6f6;
-    }
-    
-    QWidget#PrivacyDialog .QFrame#verticalFrameLeft {
-    background-color:#ffffff;
-    }
-    
-    QWidget#PrivacyDialog .QFrame#verticalFrameRight {
-    background-color:#ffffff;
-    }
-    
-    QWidget#PrivacyDialog .QToolButton {
-    margin:2px;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-color: #f7f7f7;
+    color: #333;
+}
+
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::seperator {}
+
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::indicator {
+    /* Coin Control Widget Checkbox */
+}
+
+QDialog#ZPivControlDialog .QTreeWidget#treeWidget {
+    /* zPIV Control Widget Container */
+    outline: 0;
+    background-color: #ffffff;
+    border: 1px solid #333;
+}
+
+/**************************** RECEIVE COINS *********************************************/
+
+QWidget#ReceiveCoinsDialog {
+    background-color: #fff;
+}
+
+QWidget#ReceiveCoinsDialog .QFrame#frame {
+    background-color: #ffffff;
+}
+
+QWidget#ReceiveCoinsDialog .QFrame#frame2 {
+    background-color: #ffffff;
+}
+
+QWidget#ReceiveCoinsDialog .QFrame#frame2>.QLabel {
+    /* Receive Coin Labels */
+    min-width: 10px;
+    font-weight: bold;
+    min-height: 25px;
+    margin-right: 5px;
+    padding-right: 5px;
+}
+
+/* QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLineEdit { /* Receive Coin LineEdits */
+
+/* QWidget#ReceiveCoinsDialog .QFrame#frame2  > .QLineEdit:!focus { /* Receive Coin LineEdits */
+
+QWidget#ReceiveCoinsDialog .QFrame#frame QPushButton {
+    /* Clear Button */
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+QWidget#ReceiveCoinsDialog .QFrame#frame QPushButton:pressed {
+    border: 1px solid #9e9e9e;
+}
+
+QWidget#ReceiveCoinsDialog .QFrame#frame2 QPushButton {
+    /* Clear Button */
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+QWidget#ReceiveCoinsDialog .QFrame#frame2 QPushButton:pressed {
+    border: 1px solid #9e9e9e;
+}
+
+QWidget#ReceiveCoinsDialog .QFrame#frame .QLabel#label_6 {
+    /* Requested Payments History Label */
+    color: #304530;
+    font-weight: bold;
+    font-size: 14px;
+}
+
+/**************************** RECEIVE COINS DIALOG **************************************/
+
+QDialog#ReceiveRequestDialog QTextEdit {
+    /* Contents of Receive Coin Dialog */
+    border: 1px solid #d7d7d7;
+}
+
+/**************************** TRANSACTIONS PAGE *****************************************/
+
+TransactionView QLineEdit {
+    /* Address Filter */
+    margin-bottom: 2px;
+    margin-right: 1px;
+    min-width: 111px;
+    text-align: center;
+}
+
+TransactionView QComboBox {
+    margin-bottom: 1px;
+    margin-right: 1px;
+}
+
+QLabel#transactionSumLabel {
+    /* Example of setObjectName for widgets without name */
+    color: #333333;
+    font-weight: bold;
+}
+
+QLabel#transactionSum {
+    /* Example of setObjectName for widgets without name */
+    color: #333333;
+}
+
+/**************************** TRANSACTION DETAILS DIALOG ********************************/
+
+QDialog#TransactionDescDialog QTextEdit {
+    /* Contents of Receive Coin Dialog */
+    border: 1px solid #d7d7d7;
+}
+
+/**************************** PRIVACY PAGE *****************************************/
+
+/* QDialog#PrivacyDialog */
+
+/* QWidget#PrivacyDialog */
+
+QWidget#PrivacyDialog .QFrame[frameShape="4"] {
+    /* QFrame::HLine == 0x0004 */
+    border: 1px solid #004d00;
+}
+
+QWidget#PrivacyDialog .QFrame#frame_Content {
+    background-color: #f8f6f6;
+}
+
+QWidget#PrivacyDialog .QFrame#verticalFrameLeft {
+    background-color: #ffffff;
+}
+
+QWidget#PrivacyDialog .QFrame#verticalFrameRight {
+    background-color: #ffffff;
+}
+
+QWidget#PrivacyDialog .QToolButton {
+    margin: 2px;
     min-height: 24px;
     min-width: 24px;
-    }
-    
-    /**************************** MASTERNODE LIST *******************************************/
-    QWidget#MasternodeList .QFrame#frameList {
-    background-color:#ffffff;
-    }
-    
-    
-    /********************************* CALENDAR WIDGET **************************************/
-    
-    QCalendarView {
-    border:1px solid #333;
-    }
-    
-    QCalendarWidget QWidget#qt_calendar_navigationbar { /* Calendar widget navigation bar */
-    background-color:#4c7b4c;
-    font-weight:bold;
-    }
-    
-    QCalendarWidget QAbstractItemView { /* Calendar widget days */
-    alternate-background-color:#dedbe5;
-    background-color:#fff;
-    }
-    
-    QCalendarWidget QAbstractItemView:enabled { /* Calendar widget weekdays in month */
-    color:#333;
-    }
-    
-    QCalendarWidget QAbstractItemView:disabled { /* Calendar widget days not in month */
-    color:#818181;
-    }
-    
-    QWidget#GovernancePage .QFrame#frame_Content {
-        background-color:#ffffff;
-    }
-    
-    QWidget#GovernancePage .ProposalFrame {
-        border-radius:5px;
-        margin:2px;
-        max-height:250px;
-    }
-    
-    QWidget#GovernancePage .ProposalFrame#proposalFrame {
-        background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #7ac77a, stop: 1 #98f698);
-        border:1px solid #98f698;
-    }
-    
-    QWidget#GovernancePage .ProposalFrame#proposalFramePassing {
-        background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #00cc00, stop: 1 #00ef00);
-        border:1px solid #00ef00;
-    }
-    
-    QWidget#GovernancePage .ProposalFrame > QLabel#strProposalName, QLabel#strMonthlyPayout, QLabel#strRemainingPaymentCount {
-        font-size:18pt;
-    }
-    
-    QWidget#GovernancePage .ProposalFrame > QLabel#strProposalURL {
-        font-size:14pt;
-    }
-    
-    QWidget#GovernancePage .QScrollArea, .QWidget#scrollAreaWidgetContents {
-        background-color:#fff;
-    }
-    
-    QWidget#GovernancePage .QGridLayout#proposalGrid {
-        margin-right:35px!important;
-        padding-right:35px!important;
-    }
-    
+}
+
+/**************************** MASTERNODE LIST *******************************************/
+
+QWidget#MasternodeList .QFrame#frameList {
+    background-color: #ffffff;
+}
+
+/********************************* CALENDAR WIDGET **************************************/
+
+QCalendarView {
+    border: 1px solid #333;
+}
+
+QCalendarWidget QWidget#qt_calendar_navigationbar {
+    /* Calendar widget navigation bar */
+    background-color: #4c7b4c;
+    font-weight: bold;
+}
+
+QCalendarWidget QAbstractItemView {
+    /* Calendar widget days */
+    alternate-background-color: #dedbe5;
+    background-color: #fff;
+}
+
+QCalendarWidget QAbstractItemView:enabled {
+    /* Calendar widget weekdays in month */
+    color: #333;
+}
+
+QCalendarWidget QAbstractItemView:disabled {
+    /* Calendar widget days not in month */
+    color: #818181;
+}
+
+QWidget#GovernancePage .QFrame#frame_Content {
+    background-color: #ffffff;
+}
+
+QWidget#GovernancePage .ProposalFrame {
+    border-radius: 5px;
+    margin: 2px;
+    max-height: 250px;
+}
+
+QWidget#GovernancePage .ProposalFrame#proposalFrame {
+    background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #7ac77a, stop: 1 #98f698);
+    border: 1px solid #98f698;
+}
+
+QWidget#GovernancePage .ProposalFrame#proposalFramePassing {
+    background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #00cc00, stop: 1 #00ef00);
+    border: 1px solid #00ef00;
+}
+
+QWidget#GovernancePage .ProposalFrame>QLabel#strProposalName, QLabel#strMonthlyPayout, QLabel#strRemainingPaymentCount {
+    font-size: 18pt;
+}
+
+QWidget#GovernancePage .ProposalFrame>QLabel#strProposalURL {
+    font-size: 14pt;
+}
+
+QWidget#GovernancePage .QScrollArea, .QWidget#scrollAreaWidgetContents {
+    background-color: #fff;
+}
+
+QWidget#GovernancePage .QGridLayout#proposalGrid {
+    margin-right: 35px!important;
+    padding-right: 35px!important;
+}


### PR DESCRIPTION
First two commits re-skins the GUI, adding a green-themed colour scheme to the default CSS file.
Third commit removes the initial address created after initializing the page.

New wallet look:
![image](https://user-images.githubusercontent.com/42538664/65374995-266f4480-dc88-11e9-83e7-cef7667b6635.png)
