### PR TITLE
[QT] Remove init & request address

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -86,28 +86,18 @@ void ReceiveCoinsDialog::setModel(WalletModel* model)
         // Last 2 columns are set by the columnResizingFixer, when the table geometry is ready.
         columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(tableView, AMOUNT_MINIMUM_COLUMN_WIDTH, DATE_COLUMN_WIDTH);
 
-        // Init address field
-        QSettings settings;
-        address = settings.value("current_receive_address").toString();
-        if (address.isEmpty())
-            address = getAddress();
-        ui->reqAddress->setText(address);
-
         connect(model, SIGNAL(notifyReceiveAddressChanged()), this, SLOT(receiveAddressUsed()));
     }
 }
 
 ReceiveCoinsDialog::~ReceiveCoinsDialog()
 {
-    QSettings settings;
-    settings.setValue("current_receive_address", address);
     delete ui;
 }
 
 void ReceiveCoinsDialog::clear()
 {
     ui->reqAmount->clear();
-    ui->reqAddress->setText(address);
     ui->reqLabel->setText("");
     ui->reqMessage->setText("");
     ui->reuseAddress->setChecked(false);


### PR DESCRIPTION
The "Address" field in the Payment Request form will no longer populate upon initialization, and will not populate after generating new payment requests.

A visual example:
![image](https://user-images.githubusercontent.com/42538664/65730388-7f404200-e0b9-11e9-8373-c81a00a72be9.png)
