### PR TITLE
depends: Fix a bug where BerkeleyDB fails to recognize multibyte username folders

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -10,7 +10,6 @@ $(package)_config_opts=--disable-shared --enable-cxx --disable-replication
 $(package)_config_opts_mingw32=--enable-mingw
 $(package)_config_opts_linux=--with-pic
 $(package)_cxxflags=-std=c++11
-$(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
The UNICODE flag causes an error for Berkeley DB on Windows that requires multibyte characters such as Japanese.

The screenshot below demonstrates that this bug has been corrected.

![Screen Shot 2019-11-29 at 5 16 46](https://user-images.githubusercontent.com/12813420/69831682-ca1f3700-126d-11ea-9671-b29ffb16957e.png)